### PR TITLE
perf: replace SUBSTR join with direct key match in workorders WSA query [#DSFAAP-2391]

### DIFF
--- a/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
@@ -79,7 +79,7 @@ ws_f AS (
 ),
 wsa AS (
   SELECT
-  SUBSTR(wsa_ac.pxcoverinskey, 7) ws_id,
+  rw.work_order_id ws_id,
   wsa_ac.pyid wsa_id,
   aca.actname activity_name,
   wsa_ac.pystatuswork wsa_status,
@@ -95,9 +95,7 @@ wsa AS (
   AND
   wsa_ac.pydescription IS NULL
   AND
-  SUBSTR(wsa_ac.pxcoverinskey, 6) IS NOT NULL
-  AND
-  rw.work_order_id = SUBSTR(wsa_ac.pxcoverinskey, 7)
+  wsa_ac.pxcoverinskey = 'AH-AC-' || rw.work_order_id
 )
 
 SELECT
@@ -235,7 +233,7 @@ ws_f AS (
 ),
 wsa AS (
   SELECT
-  SUBSTR(wsa_ac.pxcoverinskey, 7) ws_id,
+  rw.work_order_id ws_id,
   wsa_ac.pyid wsa_id,
   aca.actname activity_name,
   wsa_ac.pystatuswork wsa_status,
@@ -251,9 +249,7 @@ wsa AS (
   AND
   wsa_ac.pydescription IS NULL
   AND
-  SUBSTR(wsa_ac.pxcoverinskey, 6) IS NOT NULL
-  AND
-  rw.work_order_id = SUBSTR(wsa_ac.pxcoverinskey, 7)
+  wsa_ac.pxcoverinskey = 'AH-AC-' || rw.work_order_id
 )
 
 SELECT

--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -112,7 +112,7 @@ ws_f AS (
 ),
 wsa AS (
   SELECT
-  SUBSTR(wsa_ac.pxcoverinskey, 7) ws_id,
+  rw.work_order_id ws_id,
   wsa_ac.pyid wsa_id,
   aca.actname activity_name,
   wsa_ac.pystatuswork wsa_status,
@@ -128,9 +128,7 @@ wsa AS (
   AND
   wsa_ac.pydescription IS NULL
   AND
-  SUBSTR(wsa_ac.pxcoverinskey, 6) IS NOT NULL
-  AND
-  rw.work_order_id = SUBSTR(wsa_ac.pxcoverinskey, 7)
+  wsa_ac.pxcoverinskey = 'AH-AC-' || rw.work_order_id
 )
 
 SELECT

--- a/src/lib/db/queries/find-workorders.sql
+++ b/src/lib/db/queries/find-workorders.sql
@@ -76,7 +76,7 @@ ws_f AS (
 ),
 wsa AS (
   SELECT
-  SUBSTR(wsa_ac.pxcoverinskey, 7) ws_id,
+  rw.work_order_id ws_id,
   wsa_ac.pyid wsa_id,
   aca.actname activity_name,
   wsa_ac.pystatuswork wsa_status,
@@ -92,9 +92,7 @@ wsa AS (
   AND
   wsa_ac.pydescription IS NULL
   AND
-  SUBSTR(wsa_ac.pxcoverinskey, 6) IS NOT NULL
-  AND
-  rw.work_order_id = SUBSTR(wsa_ac.pxcoverinskey, 7)
+  wsa_ac.pxcoverinskey = 'AH-AC-' || rw.work_order_id
 )
 
 SELECT

--- a/src/lib/db/queries/get-workorders.sql
+++ b/src/lib/db/queries/get-workorders.sql
@@ -109,7 +109,7 @@ ws_f AS (
 ),
 wsa AS (
   SELECT
-  SUBSTR(wsa_ac.pxcoverinskey, 7) ws_id,
+  rw.work_order_id ws_id,
   wsa_ac.pyid wsa_id,
   aca.actname activity_name,
   wsa_ac.pystatuswork wsa_status,
@@ -125,9 +125,7 @@ wsa AS (
   AND
   wsa_ac.pydescription IS NULL
   AND
-  SUBSTR(wsa_ac.pxcoverinskey, 6) IS NOT NULL
-  AND
-  rw.work_order_id = SUBSTR(wsa_ac.pxcoverinskey, 7)
+  wsa_ac.pxcoverinskey = 'AH-AC-' || rw.work_order_id
 )
 
 SELECT


### PR DESCRIPTION
## Summary

https://eaflood.atlassian.net/browse/DSFAAP-2391

The WSA CTE in the workorders GET and FIND queries was joining on `SUBSTR(pxcoverinskey, 7)`, which prevented Oracle from using any index and forced full table scans on both `AHWORK_AC` (593K rows) and `INDEX_AC_ACTIVITY` (11M rows). This was the root cause of the ~30 second query times flagged in the execution plan. Replaced with an equality match using the known `AH-AC-` prefix concatenated with the work order ID, which lets the optimizer use index lookups instead. Should bring things down to sub-second territory.

## Test plan

- [x] Verify snapshot tests pass
- [x] Run integration tests against local Oracle to confirm identical results
- [ ] Run queries against DEV DB and compare execution time with the old queries
- [ ] Jose to arrange with Adam a PROD run for the same date range (2025-12-21T23:59 to 2025-12-22T00:04) to confirm improvement