### PR TITLE
fix: deterministic ordering for POST /workorders/find [#DSFAAP-2419]

### DIFF
--- a/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
@@ -151,6 +151,12 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+ws_lu.entityid ASC,
+ws_f.entityid ASC
 "
 `;
 
@@ -305,5 +311,11 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+ws_lu.entityid ASC,
+ws_f.entityid ASC
 "
 `;

--- a/src/lib/db/queries/find-workorders.sql
+++ b/src/lib/db/queries/find-workorders.sql
@@ -148,3 +148,9 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+ws_lu.entityid ASC,
+ws_f.entityid ASC


### PR DESCRIPTION
## Summary

- Added `ORDER BY` clause to `find-workorders.sql` so livestock units, activities, and facilities come back in a consistent order — matching what `get-workorders.sql` already does.
- Sorts by workorder ID, activity sequence number, livestock unit ID, and facility ID.
- Updated test snapshots to match.

## Test plan

- [x] Existing unit tests pass with updated snapshots
- [ ] Verify affected workorders (e.g. WS-74193) return the same ordering from both GET and POST /find