### PR TITLE
fix: deterministic activity ordering for duplicate sequence numbers [#DSFAAP-2420]

### DIFF
--- a/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
@@ -151,6 +151,11 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC
 "
 `;
 
@@ -305,5 +310,10 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC
 "
 `;

--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -190,6 +190,7 @@ ac.pystatuswork IN ('Open')
 
 ORDER BY
 rw.row_num ASC,
-wsa.activitysequencenumber ASC
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC
 "
 `;

--- a/src/lib/db/queries/find-workorders.sql
+++ b/src/lib/db/queries/find-workorders.sql
@@ -148,3 +148,8 @@ AND
 ws.pyid = wsa.ws_id(+)
 AND
 ac.pxobjclass = 'AH-AC-WS'
+
+ORDER BY
+ws.pyid ASC,
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC

--- a/src/lib/db/queries/get-workorders.sql
+++ b/src/lib/db/queries/get-workorders.sql
@@ -187,4 +187,5 @@ ac.pystatuswork IN ('Open')
 
 ORDER BY
 rw.row_num ASC,
-wsa.activitysequencenumber ASC
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC


### PR DESCRIPTION
## Summary

- Adds `wsa_id` as a tiebreaker to the `ORDER BY` in both the get and find workorder queries
- Fixes an issue where WS-30002 (which has two activities sharing `sequenceNumber: 3`) was returning activities in different orders depending on which endpoint you hit
- Also adds an `ORDER BY` to `find-workorders.sql` which previously had none

## Test plan

- [ ] Verify GET /workorders and POST /workorders/find return the same activity order for WS-30002
- [ ] Spot check a few other workorders to make sure ordering hasn't regressed