### PR TITLE
DSFAAP-2421: Workorder WS-74731 returns different customer ID depending on endpoint

### DIFF
--- a/.docker-compose/oracledb/006_setup_workorders.sql
+++ b/.docker-compose/oracledb/006_setup_workorders.sql
@@ -282,6 +282,10 @@ INSERT INTO pega_data.index_ac_workschedule (
 INSERT INTO pega_data.index_ac_wsentities (entityid, pyid, pxindexpurpose, cphid)
 VALUES ('O456789', 'WS-76515', 'workScheduleCustomers', NULL);
 
+-- Add second customer to test multiple customers per workorder (DSFAAP-2421)
+INSERT INTO pega_data.index_ac_wsentities (entityid, pyid, pxindexpurpose, cphid)
+VALUES ('C123789', 'WS-76515', 'workScheduleCustomers', NULL);
+
 INSERT INTO pega_data.index_ac_wsentities (entityid, pyid, pxindexpurpose, cphid)
 VALUES ('LOC-ALPHA', 'WS-76515', 'workScheduleLocation', '01/001/0001');
 

--- a/src/lib/db/mappers/to-workorders.test.js
+++ b/src/lib/db/mappers/to-workorders.test.js
@@ -254,3 +254,50 @@ test('toWorkorders returns workorders ordered by requested ids', () => {
   expect(workorders[0].id).toBe('WO789012')
   expect(workorders[1].id).toBe('WO123456')
 })
+
+test('toWorkorders returns first customer when multiple customers exist (DSFAAP-2421)', () => {
+  const rows = [
+    {
+      ...mockWorkorderRowBase,
+      work_order_id: 'WS-76515',
+      customer_id: 'C123789'
+    },
+    {
+      ...mockWorkorderRowBase,
+      work_order_id: 'WS-76515',
+      customer_id: 'O456789'
+    }
+  ]
+
+  const workorders = toWorkorders(rows, ['WS-76515'], emptyCodeMappings)
+
+  expect(workorders).toHaveLength(1)
+  expect(workorders[0].id).toBe('WS-76515')
+  expect(workorders[0].relationships.customerOrOrganisation.data).toEqual({
+    type: 'customers',
+    id: 'C123789'
+  })
+})
+
+test('toWorkorders uses first row customer when multiple customers exist without SQL ordering', () => {
+  const rowsUnordered = [
+    {
+      ...mockWorkorderRowBase,
+      work_order_id: 'WS-TEST',
+      customer_id: 'C999999' // Appears first - this will be used
+    },
+    {
+      ...mockWorkorderRowBase,
+      work_order_id: 'WS-TEST',
+      customer_id: 'C123789' // Appears second - ignored
+    }
+  ]
+
+  const workorders = toWorkorders(rowsUnordered, ['WS-TEST'], emptyCodeMappings)
+
+  expect(workorders).toHaveLength(1)
+  expect(workorders[0].relationships.customerOrOrganisation.data).toEqual({
+    type: 'customers',
+    id: 'C999999'
+  })
+})

--- a/src/lib/db/mappers/to-workorders.test.js
+++ b/src/lib/db/mappers/to-workorders.test.js
@@ -255,7 +255,7 @@ test('toWorkorders returns workorders ordered by requested ids', () => {
   expect(workorders[1].id).toBe('WO123456')
 })
 
-test('toWorkorders returns first customer when multiple customers exist (DSFAAP-2421)', () => {
+test('toWorkorders returns first customer when multiple customers exist', () => {
   const rows = [
     {
       ...mockWorkorderRowBase,

--- a/src/lib/db/mappers/to-workorders.test.js
+++ b/src/lib/db/mappers/to-workorders.test.js
@@ -255,7 +255,7 @@ test('toWorkorders returns workorders ordered by requested ids', () => {
   expect(workorders[1].id).toBe('WO123456')
 })
 
-test('toWorkorders returns first customer when multiple customers exist', () => {
+test('toWorkorders uses first row customer when multiple customers exist', () => {
   const rows = [
     {
       ...mockWorkorderRowBase,
@@ -276,28 +276,5 @@ test('toWorkorders returns first customer when multiple customers exist', () => 
   expect(workorders[0].relationships.customerOrOrganisation.data).toEqual({
     type: 'customers',
     id: 'C123789'
-  })
-})
-
-test('toWorkorders uses first row customer when multiple customers exist without SQL ordering', () => {
-  const rowsUnordered = [
-    {
-      ...mockWorkorderRowBase,
-      work_order_id: 'WS-TEST',
-      customer_id: 'C999999' // Appears first - this will be used
-    },
-    {
-      ...mockWorkorderRowBase,
-      work_order_id: 'WS-TEST',
-      customer_id: 'C123789' // Appears second - ignored
-    }
-  ]
-
-  const workorders = toWorkorders(rowsUnordered, ['WS-TEST'], emptyCodeMappings)
-
-  expect(workorders).toHaveLength(1)
-  expect(workorders[0].relationships.customerOrOrganisation.data).toEqual({
-    type: 'customers',
-    id: 'C999999'
   })
 })

--- a/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/find-workorders.test.js.snap
@@ -161,7 +161,8 @@ ws.pyid ASC,
 wsa.activitysequencenumber ASC,
 wsa.wsa_id ASC,
 ws_lu.entityid ASC,
-ws_f.entityid ASC
+ws_f.entityid ASC,
+ws_c.entityid ASC
 "
 `;
 
@@ -326,6 +327,7 @@ ws.pyid ASC,
 wsa.activitysequencenumber ASC,
 wsa.wsa_id ASC,
 ws_lu.entityid ASC,
-ws_f.entityid ASC
+ws_f.entityid ASC,
+ws_c.entityid ASC
 "
 `;

--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -195,7 +195,7 @@ ac.pystatuswork IN ('Open')
 ORDER BY
 rw.row_num ASC,
 wsa.activitysequencenumber ASC,
-wsa.wsa_id ASC
+wsa.wsa_id ASC,
 ws_c.entityid ASC
 "
 `;

--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -196,5 +196,6 @@ ORDER BY
 rw.row_num ASC,
 wsa.activitysequencenumber ASC,
 wsa.wsa_id ASC
+ws_c.entityid ASC
 "
 `;

--- a/src/lib/db/queries/find-workorders.sql
+++ b/src/lib/db/queries/find-workorders.sql
@@ -158,4 +158,5 @@ ws.pyid ASC,
 wsa.activitysequencenumber ASC,
 wsa.wsa_id ASC,
 ws_lu.entityid ASC,
-ws_f.entityid ASC
+ws_f.entityid ASC,
+ws_c.entityid ASC

--- a/src/lib/db/queries/get-workorders.sql
+++ b/src/lib/db/queries/get-workorders.sql
@@ -192,5 +192,5 @@ ac.pystatuswork IN ('Open')
 ORDER BY
 rw.row_num ASC,
 wsa.activitysequencenumber ASC,
-wsa.wsa_id ASC
+wsa.wsa_id ASC,
 ws_c.entityid ASC

--- a/src/lib/db/queries/get-workorders.sql
+++ b/src/lib/db/queries/get-workorders.sql
@@ -193,3 +193,4 @@ ORDER BY
 rw.row_num ASC,
 wsa.activitysequencenumber ASC,
 wsa.wsa_id ASC
+ws_c.entityid ASC

--- a/src/routes/workorders/find.test.js
+++ b/src/routes/workorders/find.test.js
@@ -611,6 +611,42 @@ describe('workorders/find', () => {
     })
   })
 
+  describe('Multiple customers per workorder (DSFAAP-2421)', () => {
+    test('returns first customer alphabetically when workorder has multiple customers', async () => {
+      const server = await createServer()
+
+      const queryParams = new URLSearchParams({
+        page: '1',
+        pageSize: '10'
+      })
+
+      const url = `${path}?${queryParams.toString()}`
+
+      const response = await server.inject({
+        method: 'POST',
+        payload: {
+          ids: ['WS-76515']
+        },
+        url
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      const responseBody = /** @type {PostFindWorkordersResponse} */ (
+        response.result
+      )
+
+      expect(responseBody.data).toHaveLength(1)
+      expect(responseBody.data[0].id).toBe('WS-76515')
+      expect(
+        responseBody.data[0].relationships.customerOrOrganisation.data
+      ).toEqual({
+        type: 'customers',
+        id: 'C123789'
+      })
+    })
+  })
+
   describe('Error handling', () => {
     const queryParams = new URLSearchParams({
       page: '1',

--- a/src/routes/workorders/find.test.js
+++ b/src/routes/workorders/find.test.js
@@ -611,7 +611,7 @@ describe('workorders/find', () => {
     })
   })
 
-  describe('Multiple customers per workorder (DSFAAP-2421)', () => {
+  describe('Multiple customers per workorder', () => {
     test('returns first customer alphabetically when workorder has multiple customers', async () => {
       const server = await createServer()
 

--- a/src/routes/workorders/find.test.js
+++ b/src/routes/workorders/find.test.js
@@ -612,7 +612,7 @@ describe('workorders/find', () => {
   })
 
   describe('Multiple customers per workorder', () => {
-    test('returns first customer alphabetically when workorder has multiple customers', async () => {
+    test('returns first customer alphabetically', async () => {
       const server = await createServer()
 
       const queryParams = new URLSearchParams({

--- a/src/routes/workorders/get.test.js
+++ b/src/routes/workorders/get.test.js
@@ -393,7 +393,7 @@ describe('GET /workorders', () => {
     )
   })
 
-  test('returns first customer alphabetically when workorder has multiple customers', async () => {
+  test('returns first customer alphabetically for WS-76515', async () => {
     const server = await createServer()
 
     const query = new URLSearchParams({

--- a/src/routes/workorders/get.test.js
+++ b/src/routes/workorders/get.test.js
@@ -393,7 +393,7 @@ describe('GET /workorders', () => {
     )
   })
 
-  test('returns first customer alphabetically when workorder has multiple customers (DSFAAP-2421)', async () => {
+  test('returns first customer alphabetically when workorder has multiple customers', async () => {
     const server = await createServer()
 
     const query = new URLSearchParams({

--- a/src/routes/workorders/get.test.js
+++ b/src/routes/workorders/get.test.js
@@ -392,4 +392,36 @@ describe('GET /workorders', () => {
       'Deliberate HTTP exception from mocked execute'
     )
   })
+
+  test('returns first customer alphabetically when workorder has multiple customers (DSFAAP-2421)', async () => {
+    const server = await createServer()
+
+    const query = new URLSearchParams({
+      startActivationDate: '2024-03-01T00:00:00.000Z',
+      endActivationDate: '2024-04-01T00:00:00.000Z',
+      country: 'England',
+      page: '1',
+      pageSize: '10'
+    })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: `${path}?${query.toString()}`
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const responseBody = /** @type {Record<string, any>} */ (response.result)
+
+    const ws76515 = responseBody.data.find(
+      /** @param {Record<string, any>} workorder */
+      (workorder) => workorder.id === 'WS-76515'
+    )
+
+    expect(ws76515).toBeDefined()
+    expect(ws76515.relationships.customerOrOrganisation.data).toEqual({
+      type: 'customers',
+      id: 'C123789'
+    })
+  })
 })


### PR DESCRIPTION
- Added `ws_c.entityid ASC` to both SQL queries
- Added second customer (C123789) to WS-76515 test data to verify the fix
- Updated mapper and integration test to cover this scenario