### PR TITLE
feat: masked fields [#DSFAAP-2437]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@ LABEL uk.gov.defra.ffc.parent-image=defradigital/node-development:${PARENT_VERSI
 ARG PORT
 ARG PORT_DEBUG
 ENV PORT=${PORT}
+ENV CLIENTS_PATH=/home/node/clients.jsonc
 EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node package*.json ./
 RUN npm install
 COPY --chown=node:node ./src ./src
+COPY --chown=node:node clients.jsonc ./
 
 CMD [ "npm", "run", "docker:dev" ]
 
@@ -29,11 +31,13 @@ USER node
 
 COPY --from=development /home/node/package*.json ./
 COPY --from=development /home/node/src ./src/
+COPY --from=development /home/node/clients.jsonc ./
 
 RUN npm ci --omit=dev
 
 ARG PORT
 ENV PORT=${PORT}
+ENV CLIENTS_PATH=/home/node/clients.jsonc
 EXPOSE ${PORT}
 
 CMD [ "node", "src" ]

--- a/clients.jsonc
+++ b/clients.jsonc
@@ -1,0 +1,26 @@
+{
+  "$schema": "./clients.schema.json",
+  "wfm": {
+    "client_ids": [
+      // dev
+      "2suk0m543adsrt1vnm89hch765",
+      // test
+      "3bb2845q8hbmob4ahmd53r7s16",
+      // perf-test
+      "7pthm7vegv8c3q652gmpcrjco4",
+      // prod
+      "2nq42e5je49ffdt9f16t874laj"
+    ],
+    "scopes": ["pii"]
+  },
+  // teams app
+  "apha-integration-bridge-05112025": {
+    "client_ids": [
+      // test
+      "2ltodsaoa5rt37pff96t0721bn",
+      // perf-test
+      "49m7soe26q8ugh80sv31fp6g8g"
+    ],
+    "scopes": ["pii"]
+  }
+}

--- a/clients.schema.json
+++ b/clients.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Clients config",
+  "description": "Maps a logical client name to the OAuth client_ids that should be granted the listed scopes. Consumed by src/lib/clients/load.js to gate PII unmasking.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Path or URL to this JSON Schema. Used by editors for validation; stripped at load time."
+    }
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "client_ids": {
+        "type": "array",
+        "description": "OAuth client_ids that should be granted the listed scopes.",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "scopes": {
+        "type": "array",
+        "description": "Scopes granted to each client_id (e.g. \"pii\" to unmask PII fields).",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "required": ["client_ids", "scopes"],
+    "additionalProperties": false
+  },
+  "propertyNames": {
+    "minLength": 1
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "https-proxy-agent": "7.0.6",
         "joi": "17.13.3",
         "jose": "6.0.11",
+        "jsonc-parser": "3.3.1",
         "knex": "3.1.0",
         "mongo-locks": "3.0.2",
         "mongodb": "6.17.0",
@@ -12477,6 +12478,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "https-proxy-agent": "7.0.6",
     "joi": "17.13.3",
     "jose": "6.0.11",
+    "jsonc-parser": "3.3.1",
     "knex": "3.1.0",
     "mongo-locks": "3.0.2",
     "mongodb": "6.17.0",

--- a/src/common/helpers/client-scopes.js
+++ b/src/common/helpers/client-scopes.js
@@ -1,0 +1,80 @@
+/**
+ * Decoded JWT artifacts attached to the request by `authPlugin`. The auth
+ * plugin enforces that `client_id` is a non-empty string before the request
+ * reaches any extension, so consumers may treat it as guaranteed once auth
+ * has run. `client_id` is marked optional only because `auth: false` routes
+ * never populate artifacts.
+ *
+ * @typedef {Object} JwtArtifacts
+ * @property {string} [client_id]
+ *
+ * @typedef {import('@hapi/hapi').Request & {
+ *   app: { scopes?: string[] },
+ *   auth: { artifacts: JwtArtifacts }
+ * }} HapiRequestWithScopes
+ *
+ * @typedef {Object} ClientScopesOptions
+ * @property {import('../../lib/clients/load.js').ClientsConfig} clients
+ */
+
+/**
+ * Returns the union of scopes granted to `clientId` across every matching
+ * entry in the clients config. Returns `[]` when the client is not present.
+ *
+ * @param {string | null | undefined} clientId
+ * @param {import('../../lib/clients/load.js').ClientsConfig} clients
+ * @returns {string[]}
+ */
+export const findScopesForClient = (clientId, clients) => {
+  if (!clientId) {
+    return []
+  }
+
+  const merged = new Set()
+
+  for (const entry of Object.values(clients)) {
+    if (entry.client_ids.includes(clientId)) {
+      for (const scope of entry.scopes) {
+        merged.add(scope)
+      }
+    }
+  }
+
+  return Array.from(merged)
+}
+
+/**
+ * Hapi plugin that populates `request.app.scopes` with the scopes granted to
+ * the authenticated client. Downstream extensions (PII masking, future
+ * permission checks) read this array to gate their behaviour.
+ *
+ * Fail-closed: any request whose `client_id` is missing or unrecognised will
+ * have `request.app.scopes = []`.
+ */
+export const clientScopesPlugin = {
+  plugin: {
+    name: 'clientScopesPlugin',
+    version: '0.0.0',
+    /**
+     * @param {import('@hapi/hapi').Server} server
+     * @param {ClientScopesOptions} options
+     */
+    register: (server, options) => {
+      const { clients } = options
+
+      server.ext({
+        type: 'onPostAuth',
+        /**
+         * @param {HapiRequestWithScopes} request
+         */
+        method: (request, h) => {
+          const clientId = request.auth?.artifacts?.client_id
+
+          request.app.scopes = findScopesForClient(clientId, clients)
+
+          return h.continue
+        }
+      })
+    }
+  }
+}

--- a/src/common/helpers/client-scopes.test.js
+++ b/src/common/helpers/client-scopes.test.js
@@ -1,0 +1,303 @@
+import Hapi from '@hapi/hapi'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+
+import { mask } from '../../lib/pii/index.js'
+import { clientScopesPlugin, findScopesForClient } from './client-scopes.js'
+import { piiContextPlugin } from './pii-context.js'
+
+/**
+ * @typedef {import('@hapi/hapi').Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ */
+
+describe('findScopesForClient', () => {
+  test('returns [] for nullish clientId', () => {
+    const clients = { wfm: { client_ids: ['abc'], scopes: ['pii'] } }
+
+    expect(findScopesForClient(undefined, clients)).toEqual([])
+
+    expect(findScopesForClient(null, clients)).toEqual([])
+
+    expect(findScopesForClient('', clients)).toEqual([])
+  })
+
+  test('returns [] when no entry matches', () => {
+    const clients = { wfm: { client_ids: ['abc'], scopes: ['pii'] } }
+
+    expect(findScopesForClient('xyz', clients)).toEqual([])
+  })
+
+  test('returns the matching entry scopes', () => {
+    const clients = {
+      wfm: { client_ids: ['abc', 'def'], scopes: ['pii', 'admin'] }
+    }
+
+    expect(findScopesForClient('abc', clients)).toEqual(['pii', 'admin'])
+  })
+
+  test('unions scopes across multiple matching entries', () => {
+    const clients = {
+      legacy: { client_ids: ['abc'], scopes: ['legacy-scope'] },
+      wfm: { client_ids: ['abc'], scopes: ['pii'] }
+    }
+
+    expect(findScopesForClient('abc', clients).sort()).toEqual(
+      ['legacy-scope', 'pii'].sort()
+    )
+  })
+
+  test('returns [] for an empty clients config', () => {
+    expect(findScopesForClient('abc', {})).toEqual([])
+  })
+})
+
+const clients = {
+  wfm: { client_ids: ['pii-client'], scopes: ['pii'] },
+  legacy: { client_ids: ['no-pii-client'], scopes: ['other'] }
+}
+
+const buildServer = async () => {
+  const server = Hapi.server()
+
+  server.auth.scheme('stub-bearer', () => ({
+    authenticate: (request, h) => {
+      const clientId = request.headers['x-client-id']
+
+      if (!clientId) {
+        return h.unauthenticated(new Error('no client id'), {
+          credentials: {},
+          artifacts: {}
+        })
+      }
+
+      return h.authenticated({
+        credentials: { token: 'stub' },
+        artifacts: { client_id: clientId }
+      })
+    }
+  }))
+
+  server.auth.strategy('stub', 'stub-bearer')
+
+  await server.register({
+    plugin: clientScopesPlugin,
+    options: { clients }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/probe',
+    options: { auth: 'stub' },
+    handler: (/** @type {HapiRequestWithScopes} */ request) => ({
+      scopes: request.app.scopes
+    })
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/no-auth',
+    options: { auth: false },
+    handler: (/** @type {HapiRequestWithScopes} */ request) => ({
+      scopes: request.app.scopes
+    })
+  })
+
+  await server.initialize()
+  return server
+}
+
+describe('clientScopesPlugin', () => {
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeEach(async () => {
+    server = await buildServer()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('exposes scopes for a recognised client', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'pii-client' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ scopes: ['pii'] })
+  })
+
+  test('exposes scopes for a non-pii recognised client', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'no-pii-client' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ scopes: ['other'] })
+  })
+
+  test('exposes [] for an unknown client', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'unknown' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ scopes: [] })
+  })
+
+  test('exposes [] for routes without authentication', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/no-auth'
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ scopes: [] })
+  })
+})
+
+const buildIntegrationServer = async () => {
+  const server = Hapi.server()
+
+  server.auth.scheme('stub-bearer', () => ({
+    authenticate: (request, h) => {
+      const clientId = request.headers['x-client-id']
+
+      if (!clientId) {
+        return h.unauthenticated(new Error('no client id'), {
+          credentials: {},
+          artifacts: {}
+        })
+      }
+
+      return h.authenticated({
+        credentials: { token: 'stub' },
+        artifacts: { client_id: clientId }
+      })
+    }
+  }))
+
+  server.auth.strategy('stub', 'stub-bearer')
+
+  await server.register([
+    {
+      plugin: clientScopesPlugin,
+      options: { clients }
+    },
+    piiContextPlugin
+  ])
+
+  server.route({
+    method: 'GET',
+    path: '/probe',
+    options: { auth: 'stub' },
+    handler: async () => {
+      // Force at least one async tick so we exercise async-context propagation.
+      await new Promise((resolve) => setImmediate(resolve))
+
+      return { value: mask('John Smith') }
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/no-auth',
+    options: { auth: false },
+    handler: async () => {
+      await new Promise((resolve) => setImmediate(resolve))
+
+      return { value: mask('John Smith') }
+    }
+  })
+
+  await server.initialize()
+  return server
+}
+
+describe('clientScopesPlugin + piiContextPlugin (integration)', () => {
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeEach(async () => {
+    server = await buildIntegrationServer()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('returns unmasked PII when the client has the pii scope', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'pii-client' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'John Smith' })
+  })
+
+  test('masks PII when the client is recognised but lacks the pii scope', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'no-pii-client' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'J********h' })
+  })
+
+  test('masks PII when the client is unknown', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-client-id': 'unknown' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'J********h' })
+  })
+
+  test('masks PII for routes without authentication', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/no-auth'
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'J********h' })
+  })
+
+  test('concurrent requests do not leak masking state across each other', async () => {
+    const [unmasked, masked] = await Promise.all([
+      server.inject({
+        method: 'GET',
+        url: '/probe',
+        headers: { 'x-client-id': 'pii-client' }
+      }),
+      server.inject({
+        method: 'GET',
+        url: '/probe',
+        headers: { 'x-client-id': 'no-pii-client' }
+      })
+    ])
+
+    expect(unmasked.result).toEqual({ value: 'John Smith' })
+
+    expect(masked.result).toEqual({ value: 'J********h' })
+  })
+})

--- a/src/common/helpers/pii-context.js
+++ b/src/common/helpers/pii-context.js
@@ -1,0 +1,42 @@
+import { enterMaskingContext } from '../../lib/pii/index.js'
+
+const PII_SCOPE = 'pii'
+
+/**
+ * @typedef {import('@hapi/hapi').Request} Hapi.Request
+ * @typedef {Hapi.Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ */
+
+/**
+ * Hapi plugin that establishes the per-request masking context. Reads
+ * `request.app.scopes` (populated upstream by the client-scopes plugin) and
+ * masks PII unless the `pii` scope is present.
+ *
+ * Fail-closed: if `request.app.scopes` is not populated, masking is enabled.
+ */
+export const piiContextPlugin = {
+  plugin: {
+    name: 'piiContextPlugin',
+    version: '0.0.0',
+    /**
+     * @param {import('@hapi/hapi').Server} server
+     */
+    register: (server) => {
+      server.ext({
+        type: 'onPreHandler',
+        /**
+         * @param {HapiRequestWithScopes} request
+         */
+        method: (request, h) => {
+          const scopes = request.app.scopes ?? []
+
+          const shouldMask = !scopes.includes(PII_SCOPE)
+
+          enterMaskingContext({ shouldMask })
+
+          return h.continue
+        }
+      })
+    }
+  }
+}

--- a/src/common/helpers/pii-context.test.js
+++ b/src/common/helpers/pii-context.test.js
@@ -1,0 +1,118 @@
+import Hapi from '@hapi/hapi'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+
+import { mask } from '../../lib/pii/index.js'
+import { piiContextPlugin } from './pii-context.js'
+
+/**
+ * @typedef {import('@hapi/hapi').Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ */
+
+const buildServer = async () => {
+  const server = Hapi.server()
+
+  server.ext({
+    type: 'onPostAuth',
+    /**
+     * @param {HapiRequestWithScopes} request
+     */
+    method: (request, h) => {
+      const header = request.headers['x-scopes']
+
+      if (typeof header === 'string') {
+        request.app.scopes = header ? header.split(',') : []
+      }
+
+      return h.continue
+    }
+  })
+
+  await server.register(piiContextPlugin)
+
+  server.route({
+    method: 'GET',
+    path: '/probe',
+    handler: async () => {
+      // Force at least one async tick so we exercise async-context propagation.
+      await new Promise((resolve) => setImmediate(resolve))
+
+      return { value: mask('John Smith') }
+    }
+  })
+
+  await server.initialize()
+
+  return server
+}
+
+describe('piiContextPlugin', () => {
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeEach(async () => {
+    server = await buildServer()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('masks by default when scopes are not populated', async () => {
+    const res = await server.inject({ method: 'GET', url: '/probe' })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'J********h' })
+  })
+
+  test('masks when scopes are populated but do not include pii', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-scopes': 'other' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'J********h' })
+  })
+
+  test('does not mask when scopes include pii', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-scopes': 'pii' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'John Smith' })
+  })
+
+  test('does not mask when scopes include pii alongside other scopes', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/probe',
+      headers: { 'x-scopes': 'other,pii,admin' }
+    })
+
+    expect(res.statusCode).toBe(200)
+
+    expect(res.result).toEqual({ value: 'John Smith' })
+  })
+
+  test('concurrent requests do not leak masking context across each other', async () => {
+    const [unmasked, masked] = await Promise.all([
+      server.inject({
+        method: 'GET',
+        url: '/probe',
+        headers: { 'x-scopes': 'pii' }
+      }),
+      server.inject({ method: 'GET', url: '/probe' })
+    ])
+
+    expect(unmasked.result).toEqual({ value: 'John Smith' })
+
+    expect(masked.result).toEqual({ value: 'J********h' })
+  })
+})

--- a/src/config.js
+++ b/src/config.js
@@ -380,6 +380,14 @@ const config = convict({
       default: 50,
       env: 'PAGINATION_MAX_PAGE_SIZE'
     }
+  },
+  clients: {
+    path: {
+      doc: 'Path to the clients config (JSONC)',
+      format: String,
+      default: './clients.jsonc',
+      env: 'CLIENTS_PATH'
+    }
   }
 })
 

--- a/src/lib/clients/load.js
+++ b/src/lib/clients/load.js
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs'
+import Joi from 'joi'
+import { parse, printParseErrorCode } from 'jsonc-parser'
+
+/**
+ * @typedef {Object} ClientEntry
+ * @property {string[]} client_ids
+ * @property {string[]} scopes
+ *
+ * @typedef {Record<string, ClientEntry>} ClientsConfig
+ */
+
+const entrySchema = Joi.object({
+  client_ids: Joi.array().items(Joi.string().min(1)).required(),
+  scopes: Joi.array().items(Joi.string().min(1)).required()
+}).required()
+
+const clientsSchema = Joi.object()
+  .pattern(Joi.string().min(1), entrySchema)
+  .required()
+
+/**
+ * @param {string} filePath
+ */
+const loadFile = (filePath) => {
+  try {
+    return readFileSync(filePath, 'utf8')
+  } catch (err) {
+    let reason = String(err)
+
+    if (err instanceof Error) {
+      reason = err.message
+    }
+
+    throw new Error(`Failed to read clients config at ${filePath}: ${reason}`)
+  }
+}
+
+/**
+ * @param {string} raw
+ * @param {string} filePath
+ */
+const parseClients = (raw, filePath) => {
+  /** @type {import('jsonc-parser').ParseError[]} */
+  const errors = []
+
+  const parsed = parse(raw, errors, { allowTrailingComma: true })
+
+  if (errors.length > 0) {
+    const reason = errors
+      .map((e) => `${printParseErrorCode(e.error)} at offset ${e.offset}`)
+      .join(', ')
+
+    throw new Error(`Failed to parse clients config at ${filePath}: ${reason}`)
+  }
+
+  return parsed
+}
+
+/**
+ * Reads and validates the clients config file. Accepts JSONC syntax (comments
+ * and trailing commas) so the team can annotate entries inline. Throws on
+ * missing file, invalid JSONC, or schema mismatch — callers are expected to
+ * surface these at boot time so misconfiguration fails fast rather than
+ * silently masking everything.
+ *
+ * @param {string} filePath
+ * @returns {ClientsConfig}
+ */
+export const loadClients = (filePath) => {
+  const file = loadFile(filePath)
+
+  const parsed = parseClients(file, filePath)
+
+  // `$schema` is a tooling hint for editor validation; it is not part of the
+  // runtime config and would be rejected by the entry pattern below.
+  if (parsed && typeof parsed === 'object' && '$schema' in parsed) {
+    delete parsed.$schema
+  }
+
+  const { error, value } = clientsSchema.validate(parsed, { abortEarly: false })
+
+  if (error) {
+    throw new Error(`Invalid clients config at ${filePath}: ${error.message}`)
+  }
+
+  return value
+}

--- a/src/lib/clients/load.test.js
+++ b/src/lib/clients/load.test.js
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+
+import { loadClients } from './load.js'
+
+describe('loadClients', () => {
+  /** @type {string} */
+  let dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'clients-config-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /**
+   * @param {string} contents
+   */
+  const writeConfig = (contents) => {
+    const filePath = path.join(dir, 'clients.jsonc')
+
+    writeFileSync(filePath, contents)
+
+    return filePath
+  }
+
+  test('parses a valid config', () => {
+    const filePath = writeConfig(
+      JSON.stringify({
+        wfm: { client_ids: ['abc', 'def'], scopes: ['pii'] }
+      })
+    )
+
+    expect(loadClients(filePath)).toEqual({
+      wfm: { client_ids: ['abc', 'def'], scopes: ['pii'] }
+    })
+  })
+
+  test('parses an empty object', () => {
+    const filePath = writeConfig('{}')
+
+    expect(loadClients(filePath)).toEqual({})
+  })
+
+  test('strips a top-level $schema property so it is not treated as a client entry', () => {
+    const filePath = writeConfig(
+      JSON.stringify({
+        $schema: './clients.schema.json',
+        wfm: { client_ids: ['abc'], scopes: ['pii'] }
+      })
+    )
+
+    expect(loadClients(filePath)).toEqual({
+      wfm: { client_ids: ['abc'], scopes: ['pii'] }
+    })
+  })
+
+  test('parses a config with comments and a trailing comma', () => {
+    const filePath = writeConfig(`{
+      // wfm gets unmasked PII access
+      "wfm": {
+        "client_ids": [
+          "abc", // dev
+          "def", // prod
+        ],
+        "scopes": ["pii"]
+      }
+    }`)
+
+    expect(loadClients(filePath)).toEqual({
+      wfm: { client_ids: ['abc', 'def'], scopes: ['pii'] }
+    })
+  })
+
+  test('throws when the file is missing', () => {
+    expect(() => loadClients(path.join(dir, 'missing.jsonc'))).toThrow(
+      /Failed to read clients config/
+    )
+  })
+
+  test('throws when the file is not valid JSONC', () => {
+    const filePath = writeConfig('{ not json')
+
+    expect(() => loadClients(filePath)).toThrow(
+      /Failed to parse clients config/
+    )
+  })
+
+  test('throws when an entry is missing client_ids', () => {
+    const filePath = writeConfig(JSON.stringify({ wfm: { scopes: ['pii'] } }))
+
+    expect(() => loadClients(filePath)).toThrow(/Invalid clients config/)
+  })
+
+  test('throws when an entry is missing scopes', () => {
+    const filePath = writeConfig(
+      JSON.stringify({ wfm: { client_ids: ['abc'] } })
+    )
+
+    expect(() => loadClients(filePath)).toThrow(/Invalid clients config/)
+  })
+
+  test('throws when client_ids contains a non-string', () => {
+    const filePath = writeConfig(
+      JSON.stringify({ wfm: { client_ids: ['abc', 42], scopes: ['pii'] } })
+    )
+
+    expect(() => loadClients(filePath)).toThrow(/Invalid clients config/)
+  })
+
+  test('throws when an entry has unknown keys', () => {
+    const filePath = writeConfig(
+      JSON.stringify({
+        wfm: { client_ids: ['abc'], scopes: ['pii'], extra: true }
+      })
+    )
+
+    expect(() => loadClients(filePath)).toThrow(/Invalid clients config/)
+  })
+})

--- a/src/lib/db/mappers/create-customer.js
+++ b/src/lib/db/mappers/create-customer.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableString } from './as-nullable-string.js'
 
 /**
@@ -22,10 +23,10 @@ export const createCustomer = (row, id) => {
   return {
     type: 'customers',
     id,
-    title,
-    firstName,
-    middleName,
-    lastName,
+    title: mask(title),
+    firstName: mask(firstName),
+    middleName: mask(middleName),
+    lastName: mask(lastName),
     addresses: [],
     contactDetails: [],
     relationships: {

--- a/src/lib/db/mappers/create-customer.test.js
+++ b/src/lib/db/mappers/create-customer.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { createCustomer } from './create-customer.js'
 
 test('createCustomer maps a person row into the customer response skeleton', () => {
@@ -29,6 +30,29 @@ test('createCustomer maps a person row into the customer response skeleton', () 
         data: []
       }
     }
+  })
+})
+
+test('createCustomer masks name fields when masking context is active', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const customer = createCustomer(
+      {
+        title: 'Mr',
+        first_name: 'Bert',
+        second_name: 'Albert',
+        last_name: 'Farmer',
+        organisation_name: null,
+        primary_contact_full_name: null
+      },
+      'C123456'
+    )
+
+    expect(customer).toMatchObject({
+      title: '**',
+      firstName: '****',
+      middleName: 'A****t',
+      lastName: 'F****r'
+    })
   })
 })
 

--- a/src/lib/db/mappers/create-location.js
+++ b/src/lib/db/mappers/create-location.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableString } from './as-nullable-string.js'
 import { toAddress } from './to-address.js'
 
@@ -16,7 +17,7 @@ export const createLocation = (row, id) => {
   const location = {
     type: 'locations',
     id,
-    name: asNullableString(row.feature_name),
+    name: mask(asNullableString(row.feature_name)),
     address,
     osMapReference: asNullableString(row.os_map_reference),
     livestockUnits: [],

--- a/src/lib/db/mappers/create-location.test.js
+++ b/src/lib/db/mappers/create-location.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { createLocation } from './create-location.js'
 
 test('createLocation maps a location row into the location response skeleton', () => {
@@ -52,5 +53,35 @@ test('createLocation maps a location row into the location response skeleton', (
         data: []
       }
     }
+  })
+})
+
+test('createLocation masks premises name and address line fields when masking context is active', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const location = createLocation(
+      {
+        paon_start_number: 123,
+        paon_start_number_suffix: 'A',
+        street: 'Main Street',
+        town: 'London',
+        postcode: 'SW1A 1AA',
+        country_code: 'GB',
+        uk_internal_code: 'GB',
+        county: 'County',
+        feature_name: 'Smith Farm',
+        os_map_reference: 'TQ123456'
+      },
+      'L97339'
+    )
+
+    expect(location.name).toBe('S********m')
+    expect(location.address).toMatchObject({
+      street: 'M*********t',
+      town: 'L****n',
+      postcode: 'S******A',
+      county: 'C****y',
+      countryCode: 'GB'
+    })
+    expect(location.osMapReference).toBe('TQ123456')
   })
 })

--- a/src/lib/db/mappers/create-organisation.js
+++ b/src/lib/db/mappers/create-organisation.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableString } from './as-nullable-string.js'
 
 /**
@@ -16,16 +17,16 @@ export const createOrganisation = (row, id) => {
   return {
     type: 'organisations',
     id,
-    organisationName,
+    organisationName: mask(organisationName),
     address: null,
     contactDetails: {
       primaryContact: {
-        fullName: asNullableString(row.primary_contact_full_name),
+        fullName: mask(asNullableString(row.primary_contact_full_name)),
         emailAddress: null,
         phoneNumber: null
       },
       secondaryContact: {
-        fullName: asNullableString(row.secondary_contact_full_name),
+        fullName: mask(asNullableString(row.secondary_contact_full_name)),
         emailAddress: null,
         phoneNumber: null
       }

--- a/src/lib/db/mappers/create-organisation.test.js
+++ b/src/lib/db/mappers/create-organisation.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { createOrganisation } from './create-organisation.js'
 
 test('createOrganisation maps an organisation row into the response skeleton', () => {
@@ -34,6 +35,27 @@ test('createOrganisation maps an organisation row into the response skeleton', (
         data: []
       }
     }
+  })
+})
+
+test('createOrganisation masks organisation name and contact full names when masking context is active', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const organisation = createOrganisation(
+      {
+        organisation_name: 'Acme Farms Ltd',
+        primary_contact_full_name: 'Jane Contact',
+        secondary_contact_full_name: 'John Contact'
+      },
+      'O123456'
+    )
+
+    expect(organisation.organisationName).toBe('A************d')
+    expect(organisation.contactDetails.primaryContact.fullName).toBe(
+      'J**********t'
+    )
+    expect(organisation.contactDetails.secondaryContact.fullName).toBe(
+      'J**********t'
+    )
   })
 })
 

--- a/src/lib/db/mappers/to-address.js
+++ b/src/lib/db/mappers/to-address.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableNumber } from './as-nullable-number.js'
 import { asNullableString } from './as-nullable-string.js'
 import { asPreferredFlag } from './as-preferred-flag.js'
@@ -21,11 +22,11 @@ export const toAddress = (row) => {
       endNumberSuffix: asNullableString(row.saon_end_number_suffix),
       description: asNullableString(row.saon_description)
     },
-    street: asNullableString(row.street),
-    locality: asNullableString(row.locality),
-    town: asNullableString(row.town),
-    county: asNullableString(row.county),
-    postcode: asNullableString(row.postcode),
+    street: mask(asNullableString(row.street)),
+    locality: mask(asNullableString(row.locality)),
+    town: mask(asNullableString(row.town)),
+    county: mask(asNullableString(row.county)),
+    postcode: mask(asNullableString(row.postcode)),
     countryCode: asNullableString(row.uk_internal_code),
     isPreferred: asPreferredFlag(row.preferred_contact_method_ind)
   }

--- a/src/lib/db/mappers/to-address.test.js
+++ b/src/lib/db/mappers/to-address.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { toAddress } from './to-address.js'
 
 test('toAddress still returns full address object even when no address fields are populated', () => {
@@ -89,5 +90,43 @@ test('toAddress maps populated fields to API address shape', () => {
     postcode: '1AA A11',
     countryCode: null,
     isPreferred: false
+  })
+})
+
+test('toAddress masks address line fields and postcode but leaves countryCode and addressable-object numbers unchanged', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const address = toAddress({
+      paon_start_number: '12',
+      paon_start_number_suffix: 'A',
+      paon_end_number: null,
+      paon_end_number_suffix: null,
+      paon_description: 'Rose cottage',
+      saon_start_number: null,
+      saon_start_number_suffix: null,
+      saon_end_number: null,
+      saon_end_number_suffix: null,
+      saon_description: null,
+      street: 'Acacia Avenue',
+      locality: 'West Side',
+      town: 'Town',
+      county: 'Devon',
+      postcode: 'SW1A 1AA',
+      uk_internal_code: 'GB',
+      preferred_contact_method_ind: 'N'
+    })
+
+    expect(address.street).toBe('A***********e')
+    expect(address.locality).toBe('W*******e')
+    expect(address.town).toBe('****')
+    expect(address.county).toBe('*****')
+    expect(address.postcode).toBe('S******A')
+    expect(address.countryCode).toBe('GB')
+    expect(address.primaryAddressableObject).toEqual({
+      startNumber: 12,
+      startNumberSuffix: 'A',
+      endNumber: null,
+      endNumberSuffix: null,
+      description: 'Rose cottage'
+    })
   })
 })

--- a/src/lib/db/mappers/to-organisation.js
+++ b/src/lib/db/mappers/to-organisation.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableString } from './as-nullable-string.js'
 import { createOrganisation } from './create-organisation.js'
 import { toAddress } from './to-address.js'
@@ -56,13 +57,14 @@ export const toOrganisation = (row) => {
     asNullableString(row.mobile_number) ?? asNullableString(row.landline)
 
   if (phoneNumber) {
-    organisation.contactDetails.primaryContact.phoneNumber = phoneNumber
+    organisation.contactDetails.primaryContact.phoneNumber = mask(phoneNumber)
   }
 
   const secondaryEmail = asNullableString(row.email)
 
   if (secondaryEmail) {
-    organisation.contactDetails.secondaryContact.emailAddress = secondaryEmail
+    organisation.contactDetails.secondaryContact.emailAddress =
+      mask(secondaryEmail)
   }
 
   const plantId = asNullableString(row.srabpi_plantid)

--- a/src/lib/db/mappers/to-organisation.test.js
+++ b/src/lib/db/mappers/to-organisation.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { toOrganisation } from './to-organisation.js'
 
 test('toOrganisation returns null when party id is missing', () => {
@@ -164,6 +165,60 @@ test('toOrganisation emits a full address object when address fields are empty',
         data: []
       }
     }
+  })
+})
+
+test('toOrganisation masks names, address, primary phone and secondary email when masking context is active', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const organisation = toOrganisation({
+      party_id: 'O123456',
+      customer_type: 'ORGANISATION',
+      organisation_name: 'Farming Ltd',
+      primary_contact_full_name: 'Bob Farmer',
+      secondary_contact_full_name: 'Roberta Farmer',
+      paon_start_number: null,
+      paon_start_number_suffix: null,
+      paon_end_number: null,
+      paon_end_number_suffix: null,
+      paon_description: null,
+      saon_start_number: null,
+      saon_start_number_suffix: null,
+      saon_end_number: null,
+      saon_end_number_suffix: null,
+      saon_description: null,
+      street: 'Acacia Avenue',
+      locality: null,
+      town: 'Town',
+      county: 'Devon',
+      postcode: 'SW1A 1AA',
+      uk_internal_code: 'GB',
+      preferred_contact_method_ind: null,
+      email: 'org@example.com',
+      mobile_number: null,
+      landline: '02012345678',
+      srabpi_plantid: null
+    })
+
+    expect(organisation.organisationName).toBe('F*********d')
+    expect(organisation.contactDetails.primaryContact.fullName).toBe(
+      'B********r'
+    )
+    expect(organisation.contactDetails.secondaryContact.fullName).toBe(
+      'R************r'
+    )
+    expect(organisation.contactDetails.primaryContact.phoneNumber).toBe(
+      '0*********8'
+    )
+    expect(organisation.contactDetails.secondaryContact.emailAddress).toBe(
+      'o*************m'
+    )
+    expect(organisation.address).toMatchObject({
+      street: 'A***********e',
+      town: '****',
+      county: '*****',
+      postcode: 'S******A',
+      countryCode: 'GB'
+    })
   })
 })
 

--- a/src/lib/db/mappers/to-person.js
+++ b/src/lib/db/mappers/to-person.js
@@ -1,3 +1,4 @@
+import { mask } from '../../pii/index.js'
 import { asNullableString } from './as-nullable-string.js'
 import { asPreferredFlag } from './as-preferred-flag.js'
 import { createCustomer } from './create-customer.js'
@@ -50,13 +51,13 @@ export const toPerson = (row) => {
     if (detail.type === 'email') {
       customer.contactDetails.push({
         type: detail.type,
-        emailAddress: detail.value,
+        emailAddress: mask(detail.value),
         isPreferred: asPreferredFlag(detail.preferred)
       })
     } else {
       customer.contactDetails.push({
         type: detail.type,
-        phoneNumber: detail.value,
+        phoneNumber: mask(detail.value),
         isPreferred: asPreferredFlag(detail.preferred)
       })
     }

--- a/src/lib/db/mappers/to-person.test.js
+++ b/src/lib/db/mappers/to-person.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 
+import { runWithMaskingContext } from '../../pii/index.js'
 import { toPerson } from './to-person.js'
 
 test('toPerson returns null when party id is missing', () => {
@@ -99,6 +100,63 @@ test('toPerson maps a single row into one customer resource', () => {
         ]
       }
     }
+  })
+})
+
+test('toPerson masks names, address and contact details when masking context is active', () => {
+  runWithMaskingContext({ shouldMask: true }, () => {
+    const customer = toPerson({
+      party_id: 'C123456',
+      customer_type: 'PERSON',
+      title: 'Mr',
+      first_name: 'Bert',
+      second_name: null,
+      last_name: 'Farmer',
+      paon_start_number: 12,
+      paon_start_number_suffix: null,
+      paon_end_number: null,
+      paon_end_number_suffix: null,
+      paon_description: 'Rose cottage',
+      saon_start_number: null,
+      saon_start_number_suffix: null,
+      saon_end_number: null,
+      saon_end_number_suffix: null,
+      saon_description: null,
+      street: 'Acacia Avenue',
+      locality: null,
+      town: 'Town',
+      county: 'Devon',
+      postcode: 'SW1A 1AA',
+      uk_internal_code: 'GB',
+      preferred_contact_method_ind: 'N',
+      email: 'bert@example.com',
+      email_preferred_ind: 'N',
+      mobile_number: '07700900123',
+      mobile_preferred_ind: 'Y',
+      landline: null,
+      landline_preferred_ind: null,
+      srabpi_plantid: null
+    })
+
+    expect(customer).toMatchObject({
+      title: '**',
+      firstName: '****',
+      lastName: 'F****r',
+      addresses: [
+        expect.objectContaining({
+          street: 'A***********e',
+          town: '****',
+          county: '*****',
+          postcode: 'S******A',
+          countryCode: 'GB'
+        })
+      ]
+    })
+
+    const email = customer.contactDetails.find((c) => c.type === 'email')
+    const mobile = customer.contactDetails.find((c) => c.type === 'mobile')
+    expect(email.emailAddress).toBe('b**************m')
+    expect(mobile.phoneNumber).toBe('0*********3')
   })
 })
 

--- a/src/lib/pii/index.js
+++ b/src/lib/pii/index.js
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const storage = new AsyncLocalStorage()
+
+/**
+ * Runs `fn` inside an async context that carries a masking decision.
+ *
+ * @template T
+ * @param {{ shouldMask: boolean }} context
+ * @param {() => T} fn
+ * @returns {T}
+ */
+export const runWithMaskingContext = (context, fn) => storage.run(context, fn)
+
+/**
+ * Sets the masking context for the rest of the current async chain. Used by
+ * the Hapi plugin so a per-request `onPreHandler` extension does not need to
+ * wrap the route handler.
+ *
+ * @param {{ shouldMask: boolean }} context
+ */
+export const enterMaskingContext = (context) => storage.enterWith(context)
+
+/**
+ * Masks a value when the current request's masking context is active.
+ *
+ * Rule: strings of length 6 or more keep their first and last character and
+ * mask the middle (`Smithy` -> `S****y`); shorter strings (and any non-string
+ * scalar coerced to string) are fully masked. Null, undefined and empty
+ * strings pass through unchanged.
+ *
+ * @param {string | null | undefined} value
+ */
+export const mask = (value) => {
+  if (storage.getStore()?.shouldMask !== true) {
+    return value
+  }
+
+  if (value === null || value === undefined || value === '') {
+    return value
+  }
+
+  const str = String(value)
+
+  if (str.length <= 5) {
+    return '*'.repeat(str.length)
+  }
+
+  const mask = '*'.repeat(str.length - 2)
+
+  return `${str[0]}${mask}${str[str.length - 1]}`
+}

--- a/src/lib/pii/index.test.js
+++ b/src/lib/pii/index.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { enterMaskingContext, mask, runWithMaskingContext } from './index.js'
+
+describe('mask', () => {
+  test('passes through when no masking context is set', () => {
+    expect(mask('John Smith')).toBe('John Smith')
+  })
+
+  test('passes through when shouldMask is false', () => {
+    runWithMaskingContext({ shouldMask: false }, () => {
+      expect(mask('John Smith')).toBe('John Smith')
+    })
+  })
+
+  test('passes through null, undefined and empty string', () => {
+    runWithMaskingContext({ shouldMask: true }, () => {
+      expect(mask(null)).toBeNull()
+
+      expect(mask(undefined)).toBeUndefined()
+
+      expect(mask('')).toBe('')
+    })
+  })
+
+  test('fully masks strings of length 5 or less', () => {
+    runWithMaskingContext({ shouldMask: true }, () => {
+      expect(mask('A')).toBe('*')
+
+      expect(mask('Mr')).toBe('**')
+
+      expect(mask('Bert')).toBe('****')
+
+      expect(mask('Smith')).toBe('*****')
+    })
+  })
+
+  test('preserves first and last character of strings longer than 5', () => {
+    runWithMaskingContext({ shouldMask: true }, () => {
+      expect(mask('Smithy')).toBe('S****y')
+
+      expect(mask('John Smith')).toBe('J********h')
+
+      expect(mask('SW1A 1AA')).toBe('S******A')
+
+      expect(mask('Acacia Avenue')).toBe('A***********e')
+    })
+  })
+
+  test('treats spaces as regular characters in the mask region', () => {
+    runWithMaskingContext({ shouldMask: true }, () => {
+      expect(mask('42 Acacia Avenue')).toBe('4**************e')
+    })
+  })
+
+  test('masks an email and a phone number using the same rule', () => {
+    runWithMaskingContext({ shouldMask: true }, () => {
+      expect(mask('john.smith@example.com')).toBe('j********************m')
+
+      expect(mask('07700900123')).toBe('0*********3')
+    })
+  })
+})
+
+describe('enterMaskingContext', () => {
+  test('sets the masking context for the rest of the current async chain', async () => {
+    await runWithMaskingContext({ shouldMask: false }, async () => {
+      expect(mask('John')).toBe('John')
+
+      // Re-enter with a different value within a fresh async tick.
+      await new Promise((resolve) => setImmediate(resolve))
+
+      enterMaskingContext({ shouldMask: true })
+
+      expect(mask('John')).toBe('****')
+    })
+  })
+
+  test('contexts in concurrent async chains do not leak into each other', async () => {
+    const masked = runWithMaskingContext({ shouldMask: true }, async () => {
+      await new Promise((resolve) => setImmediate(resolve))
+
+      return mask('John')
+    })
+
+    const unmasked = runWithMaskingContext({ shouldMask: false }, async () => {
+      await new Promise((resolve) => setImmediate(resolve))
+
+      return mask('John')
+    })
+
+    const [a, b] = await Promise.all([masked, unmasked])
+
+    expect(a).toBe('****')
+
+    expect(b).toBe('John')
+  })
+})

--- a/src/routes/locations/{locationId}.js
+++ b/src/routes/locations/{locationId}.js
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { execute } from '../../lib/db/operations/execute.js'
+import { mask } from '../../lib/pii/index.js'
 import {
   HTTPExceptionSchema,
   HTTPException,
@@ -92,11 +93,11 @@ function toAddress(row) {
       saonStartNumberSuffix: row.saon_start_number_suffix ?? null,
       saonEndNumber: row.saon_end_number ?? null,
       saonEndNumberSuffix: row.saon_end_number_suffix ?? null,
-      street: row.street ?? null,
+      street: mask(row.street ?? null),
       locality: row.locality ?? null,
-      town: row.town ?? null,
+      town: mask(row.town ?? null),
       administrativeAreaCounty: row.county ?? null,
-      postcode: row.postcode ?? null,
+      postcode: mask(row.postcode ?? null),
       ukInternalCode: row.uk_internal_code ?? null,
       countryCode: row.country_code ?? null
     }

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,9 @@ import { versionPlugin } from './common/helpers/versioning.js'
 import { opentelemetryPlugin } from './common/helpers/telemetry.js'
 import { HTTPException } from './lib/http/http-exception.js'
 import { authPlugin } from './common/helpers/auth.js'
+import { piiContextPlugin } from './common/helpers/pii-context.js'
+import { clientScopesPlugin } from './common/helpers/client-scopes.js'
+import { loadClients } from './lib/clients/load.js'
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
@@ -36,6 +39,8 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname)
  */
 async function createServer() {
   setupProxy()
+
+  const clients = loadClients(config.get('clients.path'))
 
   const server = Hapi.server({
     host: config.get('host'),
@@ -104,6 +109,18 @@ async function createServer() {
      * sets up opentelemetry tracing and metrics
      */
     opentelemetryPlugin,
+    /**
+     * populates `request.app.scopes` with the scopes granted to the
+     * authenticated client, used by downstream extensions (e.g. PII masking)
+     */
+    {
+      plugin: clientScopesPlugin,
+      options: { clients }
+    },
+    /**
+     * establishes the per-request PII masking context
+     */
+    piiContextPlugin,
     /**
      * automatically logs incoming requests
      */


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DSFAAP-2437

This change introduces the ability for us to mask sensitive PII in both lower and production environments to safeguard the personal information of real users, that were at one point backported into the test environments etc.

I have chosen to implement this change using `async_hooks`, that enable us to easily propagate context throughout the entire API, without having to "prop drill" a `hasMask: boolean` property into every function that requires information about masking.

To support this, I've had to adopt a somewhat controversial approach of using hapi's middleware, so that the context is correctly entered and exited, without us having to configure it manually inside every route. An awkward convenience that means there is less complexity throughout the API.

I have also hardcoded the `clients.jsonc` file, ensuring that the WFM team aren't suddenly seeing masked fields in their resposnes.

> For testing, I've also enabled our own team's client in the `test` and `perf-test` environment to see unmasked data.

