### PR TITLE
DSFAAP-2339: Update GET /workorders – Remove Scotland Default

### DIFF
--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -17,7 +17,7 @@ exports[`getWorkordersQuery returns the expected query for update date filter 1`
   AND
   ac.pystatuswork IN ('Open')
   AND
-  UPPER(ws.purposecountry) = 'SCOTLAND'
+  (NULL IS NULL OR UPPER(ws.purposecountry) = NULL)
   AND
   (
     ('updated' = 'activation' AND ac.wsactivationdate >= TO_TIMESTAMP('2024-01-01 00:00:00.000', 'yyyy-mm-dd hh24:mi:ss.ff3') AND ac.wsactivationdate < TO_TIMESTAMP('2024-01-01 00:05:00.001', 'yyyy-mm-dd hh24:mi:ss.ff3'))
@@ -225,7 +225,7 @@ exports[`getWorkordersQuery returns the expected query for valid parameters 1`] 
   AND
   ac.pystatuswork IN ('Open')
   AND
-  UPPER(ws.purposecountry) = 'SCOTLAND'
+  (NULL IS NULL OR UPPER(ws.purposecountry) = NULL)
   AND
   (
     ('activation' = 'activation' AND ac.wsactivationdate >= TO_TIMESTAMP('2024-01-01 00:00:00.000', 'yyyy-mm-dd hh24:mi:ss.ff3') AND ac.wsactivationdate < TO_TIMESTAMP('2024-01-01 00:05:00.001', 'yyyy-mm-dd hh24:mi:ss.ff3'))

--- a/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
+++ b/src/lib/db/queries/__snapshots__/get-workorders.test.js.snap
@@ -415,3 +415,211 @@ wsa.wsa_id ASC,
 ws_c.entityid ASC
 "
 `;
+
+exports[`getWorkordersQuery returns the expected query with country filter 1`] = `
+"WITH filtered_workorders AS (
+  SELECT DISTINCT
+    ws.pyid work_order_id,
+    ac.wsactivationdate activation_date
+
+  FROM
+  pega_data.ahwork_ac ac,
+  pega_Data.index_ac_workschedule ws
+
+  WHERE
+  ac.pzinskey = ws.pxinsindexedkey
+  AND
+  ac.pxobjclass = 'AH-AC-WS'
+  AND
+  ac.pystatuswork IN ('Open')
+  AND
+  ('WALES' IS NULL OR UPPER(ws.purposecountry) = 'WALES')
+  AND
+  (
+    ('activation' = 'activation' AND ac.wsactivationdate >= TO_TIMESTAMP('2024-01-01 00:00:00.000', 'yyyy-mm-dd hh24:mi:ss.ff3') AND ac.wsactivationdate < TO_TIMESTAMP('2024-01-01 00:05:00.001', 'yyyy-mm-dd hh24:mi:ss.ff3'))
+    OR
+    ('activation' = 'updated' AND ac.pxupdatedatetime >= TO_TIMESTAMP('2024-01-01 00:00:00.000', 'yyyy-mm-dd hh24:mi:ss.ff3') AND ac.pxupdatedatetime < TO_TIMESTAMP('2024-01-01 00:05:00.001', 'yyyy-mm-dd hh24:mi:ss.ff3'))
+  )
+),
+ordered_workorders AS (
+  SELECT
+  work_order_id,
+  ROW_NUMBER() OVER (ORDER BY activation_date ASC, work_order_id ASC) row_num
+
+  FROM
+  filtered_workorders
+),
+requested_workorders AS (
+  SELECT
+  work_order_id,
+  row_num
+
+  FROM
+  ordered_workorders
+
+  WHERE
+  row_num > 0
+  AND
+  row_num <= 0 + 11
+),
+ws_entities AS (
+  SELECT /*+ MATERIALIZE */
+  wsl.pyid,
+  wsl.pxindexpurpose,
+  wsl.entityid,
+  wsl.cphid
+
+  FROM
+  pega_Data.index_ac_wsentities wsl,
+  requested_workorders rw
+
+  WHERE
+  rw.work_order_id = wsl.pyid
+  AND
+  wsl.pxindexpurpose IN (
+    'workScheduleLocation',
+    'workScheduleCustomers',
+    'workScheduleLivestockUnits',
+    'workScheduleFacilities'
+  )
+),
+ws_loc AS (
+  SELECT
+  pyid,
+  entityid,
+  cphid
+
+  FROM
+  ws_entities
+
+  WHERE
+  pxindexpurpose = 'workScheduleLocation'
+),
+ws_c AS (
+  SELECT
+  pyid,
+  entityid
+
+  FROM
+  ws_entities
+
+  WHERE
+  pxindexpurpose = 'workScheduleCustomers'
+),
+ws_lu AS (
+  SELECT
+  pyid,
+  entityid
+
+  FROM
+  ws_entities
+
+  WHERE
+  pxindexpurpose = 'workScheduleLivestockUnits'
+),
+ws_f AS (
+  SELECT
+  pyid,
+  entityid
+
+  FROM
+  ws_entities
+
+  WHERE
+  pxindexpurpose = 'workScheduleFacilities'
+),
+wsa AS (
+  SELECT
+  rw.work_order_id ws_id,
+  wsa_ac.pyid wsa_id,
+  aca.actname activity_name,
+  wsa_ac.pystatuswork wsa_status,
+  wsa_ac.activitysequencenumber,
+  wsa_ac.activityrequiredflag,
+  wsa_ac.workbasketname,
+  op.pyusername assigned_to
+
+  FROM
+  pega_Data.ahwork_ac wsa_ac,
+  pega_data.index_ac_activity aca,
+  pega_data.pr_operators op,
+  requested_workorders rw
+
+  WHERE
+  wsa_ac.pxinsname = aca.pyid
+  AND
+  wsa_ac.pydescription IS NULL
+  AND
+  wsa_ac.pxcoverinskey = 'AH-AC ' || rw.work_order_id
+  AND
+  wsa_ac.pyassignedoperator = op.pyuseridentifier(+)
+)
+
+SELECT
+DISTINCT rw.row_num page_order,
+ws.pyid work_order_id,
+ws.purposeworkarea work_area,
+ws.purposecountry country,
+ws.aimname aim,
+ws.businessarea business_area,
+ws.purposename purpose,
+ws.speciesforpurpose purpose_species,
+ac.pystatuswork ws_status,
+ws_loc.entityid location_id,
+ws_loc.cphid cph,
+ws_c.entityid customer_id,
+ws_lu.entityid livestock_unit_id,
+ws_f.entityid facility_unit_id,
+wsa.wsa_id,
+wsa.activity_name,
+wsa.wsa_status activity_status,
+ws.phase,
+wsa.activitysequencenumber,
+wsa.activityrequiredflag,
+wsa.workbasketname,
+wsa.assigned_to,
+TO_CHAR(ac.wsactivationdate, 'yyyy-mm-dd"T"hh24:mi:ss') wsactivationdate,
+TO_CHAR(ac.wsearliestactivitystartdate, 'yyyy-mm-dd"T"hh24:mi:ss') wsearliestactivitystartdate,
+TO_CHAR(ac.pysladeadline, 'yyyy-mm-dd"T"hh24:mi:ss') target_date,
+TO_CHAR(ac.pxupdatedatetime, 'yyyy-mm-dd"T"hh24:mi:ss') updated_date
+-- Dates that don't seem to be used at the moment, but may be useful in the future:
+-- TO_CHAR(ac.wsstartdate, 'yyyy-mm-dd') wsstartdate,
+-- TO_CHAR(ac.wslatestactivitycompletiondate, 'dd/mm/yyyy hh24:mi:ss') wslatestactivitycompletiondate,
+-- TO_CHAR(ac.pysladeadline, 'yyyy-mm-dd') due_date,
+
+FROM
+requested_workorders rw,
+pega_data.ahwork_ac ac,
+pega_Data.index_ac_workschedule ws,
+ws_loc,
+ws_c,
+ws_lu,
+ws_f,
+wsa
+
+WHERE
+ac.pzinskey = ws.pxinsindexedkey
+AND
+ws.pyid = rw.work_order_id
+AND
+ac.pyid = ws_loc.pyid (+)
+AND
+ac.pyid = ws_c.pyid(+)
+AND
+ac.pyid = ws_lu.pyid(+)
+AND
+ac.pyid = ws_f.pyid(+)
+AND
+ws.pyid = wsa.ws_id(+)
+AND
+ac.pxobjclass = 'AH-AC-WS'
+AND
+ac.pystatuswork IN ('Open')
+
+ORDER BY
+rw.row_num ASC,
+wsa.activitysequencenumber ASC,
+wsa.wsa_id ASC,
+ws_c.entityid ASC
+"
+`;

--- a/src/lib/db/queries/get-workorders.js
+++ b/src/lib/db/queries/get-workorders.js
@@ -60,7 +60,9 @@ export function getWorkordersQuery(params) {
 
   const offsetRows = (value.page - 1) * value.pageSize
   const fetchRows = value.pageSize + 1
-  const normalizedCountry = value.country.trim().toUpperCase()
+  const normalizedCountry = value.country
+    ? value.country.trim().toUpperCase()
+    : null
 
   return {
     sql: query()

--- a/src/lib/db/queries/get-workorders.sql
+++ b/src/lib/db/queries/get-workorders.sql
@@ -14,7 +14,7 @@ WITH filtered_workorders AS (
   AND
   ac.pystatuswork IN ('Open')
   AND
-  UPPER(ws.purposecountry) = :country
+  (:country IS NULL OR UPPER(ws.purposecountry) = :country)
   AND
   (
     (:date_type = 'activation' AND ac.wsactivationdate >= TO_TIMESTAMP(:start_date, 'yyyy-mm-dd hh24:mi:ss.ff3') AND ac.wsactivationdate < TO_TIMESTAMP(:end_date, 'yyyy-mm-dd hh24:mi:ss.ff3'))

--- a/src/lib/db/queries/get-workorders.test.js
+++ b/src/lib/db/queries/get-workorders.test.js
@@ -70,21 +70,23 @@ describe('getWorkordersQuery', () => {
     )
   })
 
-  test('defaults country filter to SCOTLAND in SQL', () => {
+  test('includes all countries when country filter is omitted', () => {
     const { sql } = getWorkordersQuery({
       ...validParams
     })
 
-    expect(sql).toContain("UPPER(ws.purposecountry) = 'SCOTLAND'")
+    expect(sql).toContain('(NULL IS NULL OR UPPER(ws.purposecountry) = NULL)')
   })
 
-  test('normalizes provided country to uppercase in SQL', () => {
+  test('filters by specific country when provided', () => {
     const { sql } = getWorkordersQuery({
       ...validParams,
       country: 'wales'
     })
 
-    expect(sql).toContain("UPPER(ws.purposecountry) = 'WALES'")
+    expect(sql).toContain(
+      "('WALES' IS NULL OR UPPER(ws.purposecountry) = 'WALES')"
+    )
   })
 
   test('defaults page and pageSize when omitted', () => {

--- a/src/lib/db/queries/get-workorders.test.js
+++ b/src/lib/db/queries/get-workorders.test.js
@@ -44,6 +44,16 @@ describe('getWorkordersQuery', () => {
     expect(sql).toMatchSnapshot()
   })
 
+  test('returns the expected query with country filter', () => {
+    const { sql } = getWorkordersQuery({
+      ...validParams,
+      endActivationDate: '2024-01-01T00:05:00.001Z',
+      country: 'Wales'
+    })
+
+    expect(sql).toMatchSnapshot()
+  })
+
   test('uses a single ws_entities CTE scan for work schedule entities', () => {
     const { sql } = getWorkordersQuery({
       ...validParams,

--- a/src/routes/workorders/get.test.js
+++ b/src/routes/workorders/get.test.js
@@ -178,7 +178,7 @@ describe('GET /workorders', () => {
     }
   )
 
-  test('defaults country filter to Scotland when country is omitted', async () => {
+  test('does not include country filter when country is omitted', async () => {
     const server = await createServer()
     const getWorkordersSpy = jest
       .spyOn(getWorkordersOperation, 'getWorkorders')
@@ -205,11 +205,13 @@ describe('GET /workorders', () => {
       expect.objectContaining({
         startActivationDate: '2024-01-01T00:00:00.000Z',
         endActivationDate: '2024-02-01T00:00:00.000Z',
-        country: 'Scotland',
         page: 1,
         pageSize: 10
       })
     )
+    // Verify country is not in the call
+    const callArgs = getWorkordersSpy.mock.calls[0][1]
+    expect(callArgs).not.toHaveProperty('country')
   })
 
   test('filters by explicit country using case-insensitive input', async () => {

--- a/src/types/find/workorders-get.js
+++ b/src/types/find/workorders-get.js
@@ -20,9 +20,8 @@ export const GetWorkordersSchema = PaginationSchema.keys({
     .min(1)
     .valid('england', 'wales', 'scotland')
     .insensitive()
-    .default('Scotland')
     .description(
-      'Filter workorders by country (allowed: England, Wales, Scotland; default: Scotland)'
+      'Filter workorders by country (allowed: England, Wales, Scotland)'
     )
 })
   .custom((value, helpers) => {

--- a/src/types/find/workorders-get.test.js
+++ b/src/types/find/workorders-get.test.js
@@ -85,7 +85,7 @@ describe('GetWorkordersSchema', () => {
     )
   })
 
-  test('defaults country to Scotland when omitted', () => {
+  test('accepts valid request without country filter', () => {
     const result = GetWorkordersSchema.validate({
       startActivationDate: '2024-01-01T00:00:00.000Z',
       endActivationDate: '2024-02-01T00:00:00.000Z',
@@ -93,6 +93,18 @@ describe('GetWorkordersSchema', () => {
       pageSize: 10
     })
     expect(result.error).toBeUndefined()
-    expect(result.value.country).toBe('Scotland')
+    expect(result.value.country).toBeUndefined()
+  })
+
+  test('accepts valid request with country filter', () => {
+    const result = GetWorkordersSchema.validate({
+      startActivationDate: '2024-01-01T00:00:00.000Z',
+      endActivationDate: '2024-02-01T00:00:00.000Z',
+      country: 'wales',
+      page: 1,
+      pageSize: 10
+    })
+    expect(result.error).toBeUndefined()
+    expect(result.value.country).toBe('wales')
   })
 })


### PR DESCRIPTION
Update getWorkorders to remove default country filter and handle null values

<img width="2424" height="1130" alt="image" src="https://github.com/user-attachments/assets/a6d6f3e3-ce80-412c-8e1c-46a8cd337b85" />


<img width="2508" height="1120" alt="image" src="https://github.com/user-attachments/assets/26efcb38-b44c-44ea-81ec-dde045e19885" />
