### PR TITLE
fix(masking): corrected asyncstorage context entry [#DSFAAP-2437]

### DIFF
--- a/src/common/helpers/auth.js
+++ b/src/common/helpers/auth.js
@@ -13,9 +13,9 @@ const jwksCache = new Map()
 const JWKS_CACHE_TTL_MS = 3600000
 
 /**
- * @typedef {import('@hapi/hapi').Server} Server
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Server} Server
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 /**

--- a/src/common/helpers/bearer-token.js
+++ b/src/common/helpers/bearer-token.js
@@ -2,9 +2,9 @@ import Boom from '@hapi/boom'
 import { metricsCounter } from './metrics.js'
 
 /**
- * @typedef {import('@hapi/hapi').Server} Server
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Server} Server
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 /**

--- a/src/common/helpers/client-scopes.js
+++ b/src/common/helpers/client-scopes.js
@@ -1,17 +1,5 @@
 /**
- * Decoded JWT artifacts attached to the request by `authPlugin`. The auth
- * plugin enforces that `client_id` is a non-empty string before the request
- * reaches any extension, so consumers may treat it as guaranteed once auth
- * has run. `client_id` is marked optional only because `auth: false` routes
- * never populate artifacts.
- *
- * @typedef {Object} JwtArtifacts
- * @property {string} [client_id]
- *
- * @typedef {import('@hapi/hapi').Request & {
- *   app: { scopes?: string[] },
- *   auth: { artifacts: JwtArtifacts }
- * }} HapiRequestWithScopes
+ * @typedef {import('../../types/api.js').HapiRequestWithScopes} HapiRequestWithScopes
  *
  * @typedef {Object} ClientScopesOptions
  * @property {import('../../lib/clients/load.js').ClientsConfig} clients

--- a/src/common/helpers/client-scopes.test.js
+++ b/src/common/helpers/client-scopes.test.js
@@ -6,7 +6,7 @@ import { clientScopesPlugin, findScopesForClient } from './client-scopes.js'
 import { piiContextPlugin } from './pii-context.js'
 
 /**
- * @typedef {import('@hapi/hapi').Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ * @typedef {import('../../types/api.js').HapiRequestWithScopes} HapiRequestWithScopes
  */
 
 describe('findScopesForClient', () => {

--- a/src/common/helpers/pii-context.js
+++ b/src/common/helpers/pii-context.js
@@ -1,16 +1,32 @@
-import { enterMaskingContext } from '../../lib/pii/index.js'
+import { runWithMaskingContext } from '../../lib/pii/index.js'
 
 const PII_SCOPE = 'pii'
 
 /**
- * @typedef {import('@hapi/hapi').Request} Hapi.Request
- * @typedef {Hapi.Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ * @typedef {import('../../types/api.js').HapiRequestWithScopes} HapiRequestWithScopes
+ * @typedef {import('@hapi/hapi').Lifecycle.Method} HandlerMethod
  */
+
+/**
+ * Tracks the original (unwrapped) route handler for each route, keyed by the
+ * route's settings object. A WeakMap avoids mutating Hapi's `RouteSettings`
+ * type and lets entries be garbage-collected if Hapi ever removes a route.
+ *
+ * @type {WeakMap<import('@hapi/hapi').RouteSettings, HandlerMethod>}
+ */
+const originalHandlers = new WeakMap()
 
 /**
  * Hapi plugin that establishes the per-request masking context. Reads
  * `request.app.scopes` (populated upstream by the client-scopes plugin) and
  * masks PII unless the `pii` scope is present.
+ *
+ * Implementation: wraps the route handler in `runWithMaskingContext`, which
+ * uses `AsyncLocalStorage.run(...)` to create a proper async-context boundary
+ * for the masking store. `enterWith` would be simpler but is incompatible
+ * with downstream plugins that wrap the handler in their own `als.run(...)`
+ * call (e.g. the OpenTelemetry plugin's `context.with(...)`), which causes
+ * `storage.getStore()` to be undefined inside the handler.
  *
  * Fail-closed: if `request.app.scopes` is not populated, masking is enabled.
  */
@@ -28,11 +44,39 @@ export const piiContextPlugin = {
          * @param {HapiRequestWithScopes} request
          */
         method: (request, h) => {
-          const scopes = request.app.scopes ?? []
+          const { settings } = request.route
 
-          const shouldMask = !scopes.includes(PII_SCOPE)
+          if (!originalHandlers.has(settings)) {
+            originalHandlers.set(
+              settings,
+              /** @type {HandlerMethod} */ (settings.handler)
+            )
+          }
 
-          enterMaskingContext({ shouldMask })
+          const original = originalHandlers.get(settings)
+
+          if (typeof original === 'function') {
+            /**
+             * Each request reassigns the route's handler to a wrapper. The
+             * wrapper reads `request.app.scopes` from the actual calling
+             * request at invocation time (not captured in closure), so
+             * concurrent requests cannot leak each other's masking state.
+             */
+            settings.handler =
+              /**
+               * @this {null}
+               * @param {HapiRequestWithScopes} request
+               * @param {import('@hapi/hapi').ResponseToolkit} h
+               */
+              function (request, h) {
+                const scopes = request.app.scopes ?? []
+                const shouldMask = !scopes.includes(PII_SCOPE)
+
+                return runWithMaskingContext({ shouldMask }, () =>
+                  original.call(this, request, h)
+                )
+              }
+          }
 
           return h.continue
         }

--- a/src/common/helpers/pii-context.test.js
+++ b/src/common/helpers/pii-context.test.js
@@ -5,7 +5,7 @@ import { mask } from '../../lib/pii/index.js'
 import { piiContextPlugin } from './pii-context.js'
 
 /**
- * @typedef {import('@hapi/hapi').Request & { app: { scopes?: string[] }}} HapiRequestWithScopes
+ * @typedef {import('../../types/api.js').HapiRequestWithScopes} HapiRequestWithScopes
  */
 
 const buildServer = async () => {

--- a/src/common/helpers/routing.js
+++ b/src/common/helpers/routing.js
@@ -4,9 +4,9 @@ import { globSync } from 'glob'
 import path from 'node:path'
 
 /**
- * @typedef {import('@hapi/hapi').Server} Server
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Server} Server
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 /**

--- a/src/common/helpers/telemetry.js
+++ b/src/common/helpers/telemetry.js
@@ -23,10 +23,7 @@ const requestLatency5XX = meter.createGauge('request.latency.5XX', {
 })
 
 /**
- * @typedef {import('@hapi/hapi').Request} Hapi.Request
- * @typedef {import('@opentelemetry/api').Span} OpenTelemetry.Span
- *
- * @typedef {Hapi.Request & { app: { startTime: number; span: OpenTelemetry.Span }}} HapiRequestWithSpan
+ * @typedef {import('../../types/api.js').HapiRequestWithSpan} HapiRequestWithSpan
  */
 
 /**

--- a/src/common/helpers/versioning.js
+++ b/src/common/helpers/versioning.js
@@ -1,9 +1,9 @@
 'use strict'
 
 /**
- * @typedef {import('@hapi/hapi').Server} Server
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Server} Server
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 /**

--- a/src/lib/http/http-find-request.js
+++ b/src/lib/http/http-find-request.js
@@ -3,7 +3,7 @@ import { HTTPArrayResponse } from './http-response.js'
 
 export class HTTPFindRequest {
   /**
-   * @typedef {import('@hapi/hapi').Request} Request
+   * @typedef {import('../../types/api.js').Request} Request
    * @param {Request} request
    * @param {import('joi').Schema} schema
    */

--- a/src/lib/http/http-pagination-links.js
+++ b/src/lib/http/http-pagination-links.js
@@ -1,6 +1,6 @@
 export class HTTPPaginationLinks {
   /**
-   * @typedef {import('@hapi/hapi').Request} Request
+   * @typedef {import('../../types/api.js').Request} Request
    * @param {Request} request
    */
   constructor(request) {

--- a/src/routes/customers/find.test.js
+++ b/src/routes/customers/find.test.js
@@ -1,10 +1,21 @@
 import Hapi from '@hapi/hapi'
-import { describe, test, expect, jest, afterEach } from '@jest/globals'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test
+} from '@jest/globals'
 import hapiPino from 'hapi-pino'
 
 import route from './find.js'
 import { bearerTokenPlugin } from '../../common/helpers/bearer-token.js'
+import { clientScopesPlugin } from '../../common/helpers/client-scopes.js'
 import { oracleDb } from '../../common/helpers/oracledb.js'
+import { opentelemetryPlugin } from '../../common/helpers/telemetry.js'
+import { piiContextPlugin } from '../../common/helpers/pii-context.js'
 import * as executeOperation from '../../lib/db/operations/execute.js'
 
 const path = '/customers/find'
@@ -506,5 +517,113 @@ describe('POST /customers/find', () => {
         prev: null
       }
     })
+  })
+})
+
+/**
+ * End-to-end masking tests. These mirror the production plugin set
+ * (`opentelemetryPlugin` + `clientScopesPlugin` + `piiContextPlugin`) and
+ * exercise the real DB path. The OTel plugin is included on purpose: its
+ * handler wrapper was previously incompatible with our masking context, and
+ * registering it here proves the fix in [pii-context.js](../../common/helpers/pii-context.js)
+ * holds up under the same conditions that broke it in production.
+ */
+describe('POST /customers/find — PII masking integration', () => {
+  const PII_CLIENT_ID = 'pii-allowed-client'
+  const UNKNOWN_CLIENT_ID = 'unknown-client'
+
+  const clients = {
+    wfm: { client_ids: [PII_CLIENT_ID], scopes: ['pii'] }
+  }
+
+  /** @param {string} clientId */
+  const makeToken = (clientId) => {
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'none', typ: 'JWT' })
+    ).toString('base64url')
+    const body = Buffer.from(
+      JSON.stringify({ iss: 'https://mock-cognito', client_id: clientId })
+    ).toString('base64url')
+    return `${header}.${body}.sig`
+  }
+
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeAll(async () => {
+    server = Hapi.server({ port: 0 })
+
+    await server.register([
+      { plugin: hapiPino, options: { enabled: false } },
+      bearerTokenPlugin,
+      opentelemetryPlugin,
+      { plugin: clientScopesPlugin, options: { clients } },
+      piiContextPlugin,
+      oracleDb
+    ])
+
+    server.route({ ...route, path, method: 'POST' })
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  /** @param {string} clientId */
+  const inject = (clientId) =>
+    server.inject({
+      method: 'POST',
+      url: `${path}?page=1&pageSize=10`,
+      payload: { ids: [customer1.id] },
+      headers: { authorization: `Bearer ${makeToken(clientId)}` }
+    })
+
+  test('returns unmasked PII when the client_id has the pii scope', async () => {
+    const response = await inject(PII_CLIENT_ID)
+
+    expect(response.statusCode).toBe(200)
+
+    const result = /** @type {Record<string, any>} */ (response.result)
+
+    expect(result.data[0]).toEqual(customer1)
+  })
+
+  test('masks every PII field when the client_id is not in the clients config', async () => {
+    const response = await inject(UNKNOWN_CLIENT_ID)
+
+    expect(response.statusCode).toBe(200)
+
+    const result = /** @type {Record<string, any>} */ (response.result)
+
+    const [customer] = result.data
+
+    expect(customer.id).toBe(customer1.id)
+    // mask rule: <=5 chars fully masked; >5 chars keep first/last, mask middle
+    expect(customer.title).toBe('**') // Mr
+    expect(customer.firstName).toBe('****') // Bert
+    expect(customer.lastName).toBe('F****r') // Farmer
+    expect(customer.addresses[0].street).toBe('S****t') // Street
+    expect(customer.addresses[0].town).toBe('****') // Town
+    expect(customer.addresses[0].county).toBe('C****y') // County
+    expect(customer.addresses[0].postcode).toBe('1*****1') // 1AA A11
+
+    const email = customer.contactDetails.find((c) => c.type === 'email')
+    const mobile = customer.contactDetails.find((c) => c.type === 'mobile')
+
+    expect(email.emailAddress).toBe('e*****************m') // example@example.com
+    expect(mobile.phoneNumber).toBe('+*************1') // +44 11111 11111
+  })
+
+  test('does not leak masking state between concurrent requests', async () => {
+    const [unmaskedRes, maskedRes] = await Promise.all([
+      inject(PII_CLIENT_ID),
+      inject(UNKNOWN_CLIENT_ID)
+    ])
+
+    const unmasked = /** @type {Record<string, any>} */ (unmaskedRes.result)
+    const masked = /** @type {Record<string, any>} */ (maskedRes.result)
+
+    expect(unmasked.data[0].firstName).toBe('Bert')
+    expect(masked.data[0].firstName).toBe('****')
   })
 })

--- a/src/routes/oauth2/token.post.js
+++ b/src/routes/oauth2/token.post.js
@@ -12,9 +12,9 @@ import { config } from '../../config.js'
 const __dirname = new URL('.', import.meta.url).pathname
 
 /**
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseObject} ResponseObject
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseObject} ResponseObject
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 const CognitoTokenResponseSchema = Joi.object({

--- a/src/routes/oauth2/token.post.test.js
+++ b/src/routes/oauth2/token.post.test.js
@@ -13,7 +13,7 @@ import { http, HttpResponse } from 'msw'
 import { spyOnConfigMany } from '../../common/helpers/test-helpers/config.js'
 
 /**
- * @typedef {import('@hapi/hapi').Server} Server
+ * @typedef {import('../../types/api.js').Server} Server
  * @typedef {import('@hapi/hapi').ServerInjectResponse} ServerInjectResponse
  * @typedef {{message: string}} ErrorResult
  */

--- a/src/routes/swaggerui/cognito-auth.get.js
+++ b/src/routes/swaggerui/cognito-auth.get.js
@@ -6,9 +6,9 @@ import { config } from '../../config.js'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /**
- * @typedef {import('@hapi/hapi').Request} Request
- * @typedef {import('@hapi/hapi').ResponseObject} ResponseObject
- * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('../../types/api.js').Request} Request
+ * @typedef {import('../../types/api.js').ResponseObject} ResponseObject
+ * @typedef {import('../../types/api.js').ResponseToolkit} ResponseToolkit
  */
 
 /**

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -1,0 +1,51 @@
+// Shared JSDoc typedefs for Hapi infrastructure used across this service's
+// plugins and routes. Consumers re-alias the types they need with a JSDoc
+// `@typedef` that imports from this file. Keep this file JSDoc-only — it's
+// deliberately load-bearing for types, not runtime code.
+
+/**
+ * Aliases for the base Hapi types so consumers can re-import them through
+ * this file rather than restating `import('@hapi/hapi').X` everywhere.
+ *
+ * @typedef {import('@hapi/hapi').Server} Server
+ * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ * @typedef {import('@hapi/hapi').ResponseObject} ResponseObject
+ */
+
+/**
+ * Decoded JWT artifacts that the auth plugin (`authPlugin` /
+ * `bearerTokenPlugin`) attaches to the request after a successful
+ * authentication. `client_id` is optional only because routes with
+ * `auth: false` never populate artifacts; when auth has run, the plugin
+ * guarantees it is a non-empty string.
+ *
+ * @typedef {Object} JwtArtifacts
+ * @property {string} [client_id]
+ */
+
+/**
+ * A Hapi request augmented with the per-request state set by
+ * `clientScopesPlugin` (`request.app.scopes`) and the auth plugin
+ * (`request.auth.artifacts.client_id`). Used by `clientScopesPlugin` and
+ * `piiContextPlugin`.
+ *
+ * @typedef {import('@hapi/hapi').Request & {
+ *   app: { scopes?: string[] },
+ *   auth: { artifacts: JwtArtifacts }
+ * }} HapiRequestWithScopes
+ */
+
+/**
+ * A Hapi request augmented with the tracing state set by
+ * `opentelemetryPlugin` on `onRequest`.
+ *
+ * @typedef {import('@hapi/hapi').Request & {
+ *   app: {
+ *     startTime: number,
+ *     span: import('@opentelemetry/api').Span
+ *   }
+ * }} HapiRequestWithSpan
+ */
+
+export {}


### PR DESCRIPTION
`piiContextPlugin` was relying on `AsyncLocalStorage.enterWith()` to thread the per-request masking decision from `onPreHandler` into the route handler and its downstream mappers. Locally this looked correct and all unit tests passed as well as when the API was running locally. In the deployed CDP environment, however, `mask()` consistently saw `storage.getStore() === undefined` — so PII fields were never masked, regardless of the client's scopes.

**Root cause:** the `opentelemetryPlugin` — registered alongside `piiContextPlugin` — wraps every route handler in `context.with(ctx, fn)`, which is internally an `AsyncLocalStorage.run(...)` on OpenTelemetry's own ALS. When Hapi invokes that wrapped handler, the async-context boundary it introduces causes the store set by our `enterWith()` to be lost before the handler runs. 

Without the OTel plugin registered, the chain works; with it, masking silently fails for every request.

---

#### Type changes

I've also taken the time to refactor our type imports so that we have a new `src/types/api.js` file allowing us to import server, response & request state etc.