### PR TITLE
fix(security): adding issuers allowlist [#DSFAAP-2521]

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,5 +8,8 @@ OTEL_NODE_RESOURCE_DETECTORS="env,host"
 
 PORT=5676
 
+AUTH_ALLOWED_ISSUERS=https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_uVM3WyLQd
+
 # Feature Flags
 CASE_MANAGEMENT_ENABLED=true
+

--- a/.jest/setup-files.js
+++ b/.jest/setup-files.js
@@ -11,6 +11,16 @@ process.env.AWS_EMF_ENVIRONMENT = 'Local'
  */
 process.env.ORACLEDB_HEALTHCHECK_ENABLED = 'false'
 
+/**
+ * Provide a trusted issuer allowlist for the auth plugin. Tests run with
+ * NODE_ENV=test (isDevelopment === false), so the auth plugin throws at
+ * registration when AUTH_ALLOWED_ISSUERS is empty — which would break any
+ * test that boots the full server (e.g. start-server.test.js). This value
+ * matches the ISSUER constant used by auth.test.js.
+ */
+process.env.AUTH_ALLOWED_ISSUERS =
+  'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_TEST'
+
 if (process.env.ORACLE_CLIENT_LIB_DIR) {
   /**
    * @see https://www.oracle.com/database/technologies/instant-client/downloads.html

--- a/src/common/helpers/auth.js
+++ b/src/common/helpers/auth.js
@@ -1,16 +1,11 @@
-import { jwtVerify, createLocalJWKSet } from 'jose'
+import { jwtVerify, createRemoteJWKSet, customFetch, decodeJwt } from 'jose'
 import Boom from '@hapi/boom'
 import { config } from '../../config.js'
 import { metricsCounter } from './metrics.js'
 import { createLogger } from './logging/logger.js'
 import { proxyFetch } from './proxy/proxy-fetch.js'
 
-const expectedScope = config.get('auth.scope')
 const logger = createLogger()
-
-// JWKS cache to avoid fetching on every request
-const jwksCache = new Map()
-const JWKS_CACHE_TTL_MS = 3600000
 
 /**
  * @typedef {import('../../types/api.js').Server} Server
@@ -32,6 +27,66 @@ export const authPlugin = {
      * @param {Server} server - The Hapi.js server instance.
      */
     register: async (server) => {
+      const expectedScope = config.get('auth.scope')
+
+      /**
+       * alowlist of trusted token issuers. The JWKS used to verify a token is
+       * derived solely from these configured values — never from the token's own
+       * `iss` claim — which closes the auth-bypass where an attacker-chosen issuer
+       * selected the key source. Trailing slashes are stripped so an operator
+       * typo doesn't silently reject every valid token; empty entries are dropped.
+       */
+      // const issuers = config.get('auth.allowedIssuers')
+
+      /**
+       * @type {string[]}
+       */
+      const allowedIssuers = []
+
+      for (const issuer of config.get('auth.allowedIssuers')) {
+        if (issuer && typeof issuer === 'string') {
+          allowedIssuers.push(issuer.replace(/\/+$/, ''))
+        }
+      }
+
+      if (allowedIssuers.length === 0) {
+        const message =
+          'Set AUTH_ALLOWED_ISSUERS to the trusted Cognito issuer URL(s).'
+
+        // Fail loud in deployed environments (refuse to start) so a misconfigured
+        // deploy is visible rather than silently rejecting all traffic. In local
+        // development, log and fall through to reject every token at request time.
+        if (config.get('isDevelopment')) {
+          logger?.error(`${message} All tokens will be rejected.`)
+        } else {
+          throw new Error(message)
+        }
+      }
+
+      /**
+       * 1 remote JWKS resolver per trusted issuer, keyed by the exact issuer
+       * string. createRemoteJWKSet is lazy (no network here) and owns its own
+       * caching, cooldown and key-rotation handling. The JWKS fetch is routed
+       * through proxyFetch so the egress proxy is still used in deployed
+       * environments.
+       */
+      const jwksByIssuer = new Map(
+        allowedIssuers.map((issuer) => {
+          let jwksUrl
+          try {
+            jwksUrl = new URL(`${issuer}/.well-known/jwks.json`)
+          } catch {
+            throw new Error(
+              `authPlugin: invalid issuer URL in AUTH_ALLOWED_ISSUERS: "${issuer}"`
+            )
+          }
+          return [
+            issuer,
+            createRemoteJWKSet(jwksUrl, { [customFetch]: proxyFetch })
+          ]
+        })
+      )
+
       server.auth.scheme('bearer', () => {
         return {
           authenticate: async (request, h) => {
@@ -41,6 +96,7 @@ export const authPlugin = {
               logger?.warn(
                 'Authentication failed: Missing or invalid Authorization header'
               )
+
               return Boom.unauthorized('Authentication failed')
             }
 
@@ -48,67 +104,47 @@ export const authPlugin = {
 
             try {
               /**
-               * Decode the JWT payload to extract the issuer
-               * We need the issuer to construct the JWKS endpoint URL
+               * decode the JWT payload WITHOUT verifying it, only to read the
+               * issuer. The issuer is used purely to select a pre-configured JWKS
+               * resolver; it can never introduce a new JWKS URL. A malformed token
+               * makes decodeJwt throw, which the catch below maps to a 401.
                */
-              const decoded = JSON.parse(
-                Buffer.from(token.split('.')[1], 'base64url').toString('utf8')
-              )
-
-              const issuer = decoded.iss
+              const { iss: issuer } = decodeJwt(token)
 
               if (!issuer) {
                 logger?.warn(
                   'Authentication failed: Missing issuer claim in token'
                 )
+
                 return Boom.unauthorized('Authentication failed')
               }
 
-              const jwksUrl = `${issuer}/.well-known/jwks.json`
+              const JWKs = jwksByIssuer.get(issuer)
 
-              // Check cache first
-              const cached = jwksCache.get(jwksUrl)
-              let JWKS
+              // reject any token whose issuer is not in the allowlist before any
+              // JWKs fetch or signature verification.
+              if (!JWKs) {
+                logger?.warn('Authentication failed: Untrusted token issuer')
 
-              if (cached && Date.now() - cached.timestamp < JWKS_CACHE_TTL_MS) {
-                JWKS = cached.jwks
-              } else {
-                // Fetch JWKS using proxyFetch to ensure proxy is used
-                const jwksResponse = await proxyFetch(jwksUrl)
-
-                if (!jwksResponse.ok) {
-                  logger?.error('Failed to fetch JWKS from Cognito')
-                  throw new Error(
-                    `Failed to fetch JWKS: ${jwksResponse.status} ${jwksResponse.statusText}`
-                  )
-                }
-
-                const jwks = await jwksResponse.json()
-
-                // Create local JWKS for verification
-                JWKS = createLocalJWKSet(jwks)
-
-                // Cache the JWKS
-                jwksCache.set(jwksUrl, {
-                  jwks: JWKS,
-                  timestamp: Date.now()
-                })
+                return Boom.unauthorized('Authentication failed')
               }
 
-              const { payload } = await jwtVerify(token, JWKS, {
+              const { payload } = await jwtVerify(token, JWKs, {
                 issuer,
-                audience: undefined
+                algorithms: ['RS256']
               })
 
               if (payload.token_use !== 'access') {
                 logger?.warn(
                   'Authentication failed: Token is not an access token'
                 )
+
                 return Boom.unauthorized('Authentication failed')
               }
 
               if (!payload.client_id || typeof payload.client_id !== 'string') {
                 logger?.warn('Authentication failed: Missing client_id claim')
+
                 return Boom.unauthorized('Authentication failed')
               }
 
@@ -116,6 +152,7 @@ export const authPlugin = {
                 logger?.warn(
                   'Authorization failed: Required scope not present in token'
                 )
+
                 return Boom.forbidden('Insufficient permissions')
               }
 
@@ -131,25 +168,37 @@ export const authPlugin = {
               })
             } catch (err) {
               const error = err instanceof Error ? err : new Error(String(err))
+
               const errorCode = 'code' in error ? error.code : undefined
 
               // Provide specific error messages based on error type
               if (errorCode === 'ERR_JWT_EXPIRED') {
                 logger?.warn('Authentication failed: Token has expired')
+
                 return Boom.unauthorized('Token has expired')
               }
+
               if (errorCode === 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED') {
                 logger?.warn(
                   'Authentication failed: Token signature verification failed'
                 )
                 return Boom.unauthorized('Authentication failed')
               }
+
+              if (errorCode === 'ERR_JOSE_ALG_NOT_ALLOWED') {
+                logger?.warn(
+                  'Authentication failed: Disallowed token signing algorithm'
+                )
+                return Boom.unauthorized('Authentication failed')
+              }
+
               if (errorCode === 'ERR_JWT_CLAIM_VALIDATION_FAILED') {
                 logger?.warn(
                   'Authentication failed: Token claim validation failed'
                 )
                 return Boom.unauthorized('Authentication failed')
               }
+
               if (errorCode === 'ERR_JWKS_NO_MATCHING_KEY') {
                 logger?.warn(
                   'Authentication failed: No matching key found in JWKS'
@@ -157,7 +206,19 @@ export const authPlugin = {
                 return Boom.unauthorized('Authentication failed')
               }
 
+              if (errorCode === 'ERR_JWKS_TIMEOUT') {
+                // infrastructure failure (JWKS endpoint or egress proxy
+                // unreachable), not a bad token — logged distinctly so a valid
+                // token rejected for this reason is diagnosable. Status is kept
+                // at 401 to preserve prior behaviour.
+                logger?.error(
+                  'Authentication failed: Timed out fetching JWKS from issuer'
+                )
+                return Boom.unauthorized('Authentication failed')
+              }
+
               logger?.warn('Authentication failed: Invalid or malformed token')
+
               return Boom.unauthorized('Authentication failed')
             }
           }

--- a/src/common/helpers/auth.test.js
+++ b/src/common/helpers/auth.test.js
@@ -1,13 +1,16 @@
 import Hapi from '@hapi/hapi'
 import { describe, beforeAll, afterAll, test, expect } from '@jest/globals'
-import { SignJWT, generateKeyPair, exportJWK } from 'jose'
+import { SignJWT, generateKeyPair, generateSecret, exportJWK } from 'jose'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 
 import { authPlugin } from './auth.js'
+import { config } from '../../config.js'
 
 // Constants
 const ISSUER = 'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_TEST'
+const UNTRUSTED_ISSUER =
+  'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_EVIL'
 const CLIENT_ID = 'test-client-id'
 const JWKS_PATH = '/.well-known/jwks.json'
 
@@ -20,6 +23,61 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
   let privateKey
   let publicJwk
 
+  /**
+   * Signs a JWT for tests. Defaults to a valid RS256 access token for ISSUER.
+   */
+  const signToken = async ({
+    claims = {},
+    header = { alg: 'RS256', kid: 'mock-key-id' },
+    key = privateKey,
+    expiresInSeconds = 3600
+  } = {}) => {
+    const now = Math.floor(Date.now() / 1000)
+    return new SignJWT(claims)
+      .setProtectedHeader(header)
+      .setIssuedAt(now)
+      .setExpirationTime(now + expiresInSeconds)
+      .sign(key)
+  }
+
+  /**
+   * Builds a fresh Hapi server with the auth plugin registered and a single
+   * protected route. A fresh server means a fresh (cold) JWKS resolver, which
+   * lets tests assert first-fetch / no-fetch behaviour deterministically.
+   */
+  const buildSecureServer = async () => {
+    const s = Hapi.server()
+    await s.register({ plugin: authPlugin })
+    s.route({
+      method: 'GET',
+      path: '/secure',
+      options: {
+        auth: { mode: 'required' },
+        handler: (request) => ({
+          message: 'auth required',
+          user: request.auth.artifacts.sub
+        })
+      }
+    })
+    await s.initialize()
+    return s
+  }
+
+  /**
+   * Installs a JWKS handler for the given issuer that counts fetches. msw.use
+   * prepends, so this shadows any earlier handler for the same URL.
+   */
+  const countingJwks = (issuer) => {
+    const counter = { count: 0 }
+    msw.use(
+      http.get(`${issuer}${JWKS_PATH}`, () => {
+        counter.count++
+        return HttpResponse.json({ keys: [publicJwk] })
+      })
+    )
+    return counter
+  }
+
   beforeAll(async () => {
     // Generate key pair for signing test tokens
     const keypair = await generateKeyPair('RS256')
@@ -31,7 +89,8 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
     publicJwk.use = 'sig'
     publicJwk.alg = 'RS256'
 
-    // Set env
+    // Set env. AUTH_ALLOWED_ISSUERS is provided globally by .jest/setup-files.js
+    // and matches ISSUER above.
     process.env.AUTH_SCOPE = 'apha-integration-bridge-resource-srv/access'
 
     // Mock JWKS endpoint
@@ -44,19 +103,15 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
     msw.listen({ onUnhandledRequest: 'bypass' })
 
     // Generate valid token
-    const now = Math.floor(Date.now() / 1000)
-
-    token = await new SignJWT({
-      sub: 'test-user',
-      iss: ISSUER,
-      token_use: 'access',
-      scope: 'apha-integration-bridge-resource-srv/access',
-      client_id: CLIENT_ID
+    token = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: ISSUER,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      }
     })
-      .setProtectedHeader({ alg: 'RS256', kid: 'mock-key-id' })
-      .setIssuedAt(now)
-      .setExpirationTime(now + 3600)
-      .sign(privateKey)
 
     // Set up HAPI server
     server = Hapi.server()
@@ -115,19 +170,15 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
   })
 
   test('rejects token with invalid scope', async () => {
-    const now = Math.floor(Date.now() / 1000)
-
-    const badToken = await new SignJWT({
-      sub: 'test-user',
-      iss: ISSUER,
-      token_use: 'access',
-      scope: 'something-else',
-      client_id: CLIENT_ID
+    const badToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: ISSUER,
+        token_use: 'access',
+        scope: 'something-else',
+        client_id: CLIENT_ID
+      }
     })
-      .setProtectedHeader({ alg: 'RS256', kid: 'mock-key-id' })
-      .setIssuedAt(now)
-      .setExpirationTime(now + 3600)
-      .sign(privateKey)
 
     const res = await server.inject({
       method: 'GET',
@@ -140,18 +191,14 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
   })
 
   test('rejects token with missing client_id', async () => {
-    const now = Math.floor(Date.now() / 1000)
-
-    const badToken = await new SignJWT({
-      sub: 'test-user',
-      iss: ISSUER,
-      token_use: 'access',
-      scope: 'apha-integration-bridge-resource-srv/access'
+    const badToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: ISSUER,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access'
+      }
     })
-      .setProtectedHeader({ alg: 'RS256', kid: 'mock-key-id' })
-      .setIssuedAt(now)
-      .setExpirationTime(now + 3600)
-      .sign(privateKey)
 
     const res = await server.inject({
       method: 'GET',
@@ -164,19 +211,16 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
   })
 
   test('rejects expired token', async () => {
-    const now = Math.floor(Date.now() / 1000)
-
-    const expiredToken = await new SignJWT({
-      sub: 'test-user',
-      iss: ISSUER,
-      token_use: 'access',
-      scope: 'apha-integration-bridge-resource-srv/access',
-      client_id: CLIENT_ID
+    const expiredToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: ISSUER,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      },
+      expiresInSeconds: -60 // Expired 60 seconds ago
     })
-      .setProtectedHeader({ alg: 'RS256', kid: 'mock-key-id' })
-      .setIssuedAt(now - 3660)
-      .setExpirationTime(now - 60) // Expired 60 seconds ago
-      .sign(privateKey)
 
     const res = await server.inject({
       method: 'GET',
@@ -203,35 +247,226 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
     })
   })
 
-  test('uses cached JWKS on subsequent requests', async () => {
-    let jwksCallCount = 0
+  test('rejects token from an untrusted issuer without fetching its JWKS', async () => {
+    const evilJwks = countingJwks(UNTRUSTED_ISSUER)
 
-    msw.use(
-      http.get(`${ISSUER}${JWKS_PATH}`, () => {
-        jwksCallCount++
-        return HttpResponse.json({ keys: [publicJwk] })
+    const untrustedToken = await signToken({
+      claims: {
+        sub: 'attacker',
+        iss: UNTRUSTED_ISSUER,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      }
+    })
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: `Bearer ${untrustedToken}` }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+    // The attacker-controlled issuer's JWKS must never be fetched.
+    expect(evilJwks.count).toBe(0)
+  })
+
+  test('rejects token signed with a disallowed algorithm (HS256) without fetching JWKS', async () => {
+    // Cold server + counter: the algorithms pin rejects before key resolution,
+    // so no JWKS fetch should occur even though the issuer is trusted.
+    const freshServer = await buildSecureServer()
+    const jwks = countingJwks(ISSUER)
+
+    const secret = await generateSecret('HS256')
+    const hsToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: ISSUER,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      },
+      header: { alg: 'HS256' },
+      key: secret
+    })
+
+    const res = await freshServer.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: `Bearer ${hsToken}` }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+    expect(jwks.count).toBe(0)
+
+    await freshServer.stop()
+  })
+
+  test('rejects a structurally malformed token with 401, not 500', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: 'Bearer not-a-jwt' }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+  })
+
+  test('rejects a well-formed token with no iss claim without fetching JWKS', async () => {
+    // Cold server + counter: the missing-issuer guard must short-circuit before
+    // any verification work, even though the token is signed with a known kid.
+    const freshServer = await buildSecureServer()
+    const jwks = countingJwks(ISSUER)
+
+    const noIssToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      }
+    })
+
+    const res = await freshServer.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: `Bearer ${noIssToken}` }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+    expect(jwks.count).toBe(0)
+
+    await freshServer.stop()
+  })
+
+  test('rejects a token whose iss has a trailing-slash variant without fetching JWKS', async () => {
+    // The configured issuer (ISSUER, no trailing slash) is matched exactly. A
+    // token presenting a trailing-slash variant must fail closed.
+    const freshServer = await buildSecureServer()
+    const jwks = countingJwks(ISSUER)
+
+    const slashToken = await signToken({
+      claims: {
+        sub: 'test-user',
+        iss: `${ISSUER}/`,
+        token_use: 'access',
+        scope: 'apha-integration-bridge-resource-srv/access',
+        client_id: CLIENT_ID
+      }
+    })
+
+    const res = await freshServer.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: `Bearer ${slashToken}` }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+    expect(jwks.count).toBe(0)
+
+    await freshServer.stop()
+  })
+
+  test('accepts a normal token when the configured issuer has a trailing slash', async () => {
+    const previous = config.get('auth.allowedIssuers')
+    try {
+      // Operator configured the issuer with a trailing slash; it is normalised
+      // at registration so a normal (no-slash) token still authenticates.
+      config.set('auth.allowedIssuers', [`${ISSUER}/`])
+      const freshServer = await buildSecureServer()
+
+      const res = await freshServer.inject({
+        method: 'GET',
+        url: '/secure',
+        headers: { authorization: `Bearer ${token}` }
       })
-    )
 
-    // Make first request - should fetch JWKS
-    const res1 = await server.inject({
+      expect(res.statusCode).toBe(200)
+      expect(res.result).toEqual({
+        message: 'auth required',
+        user: 'test-user'
+      })
+
+      await freshServer.stop()
+    } finally {
+      config.set('auth.allowedIssuers', previous)
+    }
+  })
+
+  test('refuses to start (throws at registration) when the allowlist is empty in a non-development environment', async () => {
+    const previousIssuers = config.get('auth.allowedIssuers')
+    const previousIsDev = config.get('isDevelopment')
+    try {
+      config.set('auth.allowedIssuers', [])
+      config.set('isDevelopment', false)
+
+      const s = Hapi.server()
+      await expect(s.register({ plugin: authPlugin })).rejects.toThrow(
+        /AUTH_ALLOWED_ISSUERS/
+      )
+    } finally {
+      config.set('auth.allowedIssuers', previousIssuers)
+      config.set('isDevelopment', previousIsDev)
+    }
+  })
+
+  test('in development, an empty allowlist boots but rejects all tokens without fetching JWKS', async () => {
+    const previousIssuers = config.get('auth.allowedIssuers')
+    const previousIsDev = config.get('isDevelopment')
+    try {
+      config.set('auth.allowedIssuers', [])
+      config.set('isDevelopment', true)
+
+      const freshServer = await buildSecureServer()
+      const jwks = countingJwks(ISSUER)
+
+      const res = await freshServer.inject({
+        method: 'GET',
+        url: '/secure',
+        headers: { authorization: `Bearer ${token}` }
+      })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.result.message).toBe('Authentication failed')
+      expect(jwks.count).toBe(0)
+
+      await freshServer.stop()
+    } finally {
+      config.set('auth.allowedIssuers', previousIssuers)
+      config.set('isDevelopment', previousIsDev)
+    }
+  })
+
+  test('fetches JWKS once and reuses it on subsequent requests', async () => {
+    // Caching is now owned by jose's createRemoteJWKSet (cooldownDuration 30s /
+    // cacheMaxAge 10min). A fresh server gives a cold resolver, so the first
+    // request triggers exactly one fetch and the second is served from cache.
+    const freshServer = await buildSecureServer()
+    const jwks = countingJwks(ISSUER)
+
+    const res1 = await freshServer.inject({
       method: 'GET',
       url: '/secure',
       headers: { authorization: `Bearer ${token}` }
     })
 
     expect(res1.statusCode).toBe(200)
-    const callsAfterFirst = jwksCallCount
+    expect(jwks.count).toBe(1)
 
-    // Make second request - should use cached JWKS
-    const res2 = await server.inject({
+    const res2 = await freshServer.inject({
       method: 'GET',
       url: '/secure',
       headers: { authorization: `Bearer ${token}` }
     })
 
     expect(res2.statusCode).toBe(200)
+    expect(jwks.count).toBe(1)
 
-    expect(jwksCallCount).toBe(callsAfterFirst)
+    await freshServer.stop()
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -195,6 +195,12 @@ const config = convict({
       format: String,
       default: 'apha-integration-bridge-resource-srv/access',
       env: 'AUTH_SCOPE'
+    },
+    allowedIssuers: {
+      doc: 'Comma-separated allowlist of exact trusted token issuer (iss) URLs. Each entry should be the full Cognito issuer including the pool id, e.g. https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_xxxxxxxxx (a trailing slash, if present, is stripped). Tokens whose iss is not an exact match are rejected before any JWKS fetch. MUST be set per environment; empty causes the server to refuse to start (deployed) or reject all tokens (local development).',
+      format: Array,
+      default: [],
+      env: 'AUTH_ALLOWED_ISSUERS'
     }
   },
   log: {

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,61 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  jest
+} from '@jest/globals'
+
+describe('config auth.allowedIssuers', () => {
+  const ORIGINAL = process.env.AUTH_ALLOWED_ISSUERS
+
+  beforeEach(() => {
+    jest.resetModules()
+    delete process.env.AUTH_ALLOWED_ISSUERS
+  })
+
+  afterEach(() => {
+    delete process.env.AUTH_ALLOWED_ISSUERS
+  })
+
+  afterAll(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.AUTH_ALLOWED_ISSUERS
+    } else {
+      process.env.AUTH_ALLOWED_ISSUERS = ORIGINAL
+    }
+  })
+
+  test('defaults to [] when AUTH_ALLOWED_ISSUERS is unset', async () => {
+    delete process.env.AUTH_ALLOWED_ISSUERS
+
+    const { config } = await import('./config.js')
+
+    expect(config.get('auth.allowedIssuers')).toEqual([])
+  })
+
+  test('comma-splits AUTH_ALLOWED_ISSUERS into an array', async () => {
+    process.env.AUTH_ALLOWED_ISSUERS =
+      'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_A,https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_B'
+
+    const { config } = await import('./config.js')
+
+    expect(config.get('auth.allowedIssuers')).toEqual([
+      'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_A',
+      'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_B'
+    ])
+  })
+
+  test('treats a single issuer as a one-element array', async () => {
+    process.env.AUTH_ALLOWED_ISSUERS =
+      'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_A'
+
+    const { config } = await import('./config.js')
+
+    expect(config.get('auth.allowedIssuers')).toEqual([
+      'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_A'
+    ])
+  })
+})


### PR DESCRIPTION
[#DSFAAP-2521](https://eaflood.atlassian.net/browse/DSFAAP-2521)

This fix ensures that we only accept access tokens from one or more issuers that have been added to an allowlist.

Related PR for adding `AUTH_ALLOWED_ISSUERS` to each environment: https://github.com/DEFRA/cdp-app-config/pull/3638
