### PR TITLE
feat: suffix non-production metric names for separate alerting [#DSFAAP-2543]

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,14 @@ const isProduction = process.env.NODE_ENV === 'production'
 const isTest = process.env.NODE_ENV === 'test'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
+/**
+ * The CDP environment the service is deployed to is distinct from NODE_ENV,
+ * which is "production" in *every* deployed CDP environment. CDP_ENV identifies
+ * the specific environment (dev, test, ext-test, perf-test, prod) so behaviour
+ * can differ between real production and the lower environments.
+ */
+const isCDPProduction = (process.env.CDP_ENV ?? 'local') === 'prod'
+
 const config = convict({
   oracledb: {
     pega: {
@@ -171,6 +179,17 @@ const config = convict({
     nullable: true,
     default: null,
     env: 'SERVICE_VERSION'
+  },
+  cdpEnv: {
+    doc: 'The CDP environment the service is deployed to (e.g. dev, test, ext-test, perf-test, prod). "prod" is real production; every other value is treated as non-production. Defaults to "local" when unset (local development and tests).',
+    format: String,
+    default: 'local',
+    env: 'CDP_ENV'
+  },
+  isCDPProduction: {
+    doc: 'Whether the service is running in the production CDP environment (CDP_ENV === "prod"). Distinct from NODE_ENV, which is "production" in all deployed CDP environments.',
+    format: Boolean,
+    default: isCDPProduction
   },
   host: {
     doc: 'The IP address to bind',

--- a/src/config.js
+++ b/src/config.js
@@ -185,7 +185,7 @@ const config = convict({
    * can differ between real production and the lower environments.
    */
   isLowerEnvironment: {
-    doc: 'Whether the service is running in a lower (non-production) CDP environment',
+    doc: 'Whether the service is running in a lower (non-production) CDP environment. True whenever CDP_ENV is anything other than "prod", including when it is absent.',
     format: Boolean,
     default: process.env.CDP_ENV !== 'prod'
   },

--- a/src/config.js
+++ b/src/config.js
@@ -10,14 +10,6 @@ const isProduction = process.env.NODE_ENV === 'production'
 const isTest = process.env.NODE_ENV === 'test'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
-/**
- * The CDP environment the service is deployed to is distinct from NODE_ENV,
- * which is "production" in *every* deployed CDP environment. CDP_ENV identifies
- * the specific environment (dev, test, ext-test, perf-test, prod) so behaviour
- * can differ between real production and the lower environments.
- */
-const isCDPProduction = (process.env.CDP_ENV ?? 'local') === 'prod'
-
 const config = convict({
   oracledb: {
     pega: {
@@ -181,15 +173,21 @@ const config = convict({
     env: 'SERVICE_VERSION'
   },
   cdpEnv: {
-    doc: 'The CDP environment the service is deployed to (e.g. dev, test, ext-test, perf-test, prod). "prod" is real production; every other value is treated as non-production. Defaults to "local" when unset (local development and tests).',
+    doc: 'The CDP environment the service is deployed to (e.g. dev, test, ext-test, perf-test, prod). "prod" is real production; every other value is a lower environment. Defaults to "local" when unset (local development and tests).',
     format: String,
     default: 'local',
     env: 'CDP_ENV'
   },
-  isCDPProduction: {
-    doc: 'Whether the service is running in the production CDP environment (CDP_ENV === "prod"). Distinct from NODE_ENV, which is "production" in all deployed CDP environments.',
+  /**
+   * The CDP environment the service is deployed to is distinct from NODE_ENV,
+   * which is "production" in *every* deployed CDP environment. CDP_ENV identifies
+   * the specific environment (dev, test, ext-test, perf-test, prod) so behaviour
+   * can differ between real production and the lower environments.
+   */
+  isLowerEnvironment: {
+    doc: 'Whether the service is running in a lower (non-production) CDP environment',
     format: Boolean,
-    default: isCDPProduction
+    default: process.env.CDP_ENV !== 'prod'
   },
   host: {
     doc: 'The IP address to bind',

--- a/src/lib/telemetry/emf-metrics-exporter.js
+++ b/src/lib/telemetry/emf-metrics-exporter.js
@@ -2,6 +2,7 @@ import { ConsoleMetricExporter } from '@opentelemetry/sdk-metrics'
 import { StorageResolution, Unit } from 'aws-embedded-metrics'
 
 import { createLogger } from '../../common/helpers/logging/logger.js'
+import { applyNonProductionMetricName } from './metric-naming.js'
 
 const logger = createLogger()
 
@@ -77,10 +78,11 @@ export class EMFMetricExporter extends ConsoleMetricExporter {
             for (const datapoint of metric.dataPoints) {
               /**
                * push the metric that has been recorded inside
-               * opentelemetry to EMF
+               * opentelemetry to EMF, applying the non-production naming
+               * policy so prod and non-prod can be alerted on separately
                */
               emf.putMetric(
-                metric.descriptor.name,
+                applyNonProductionMetricName(metric.descriptor.name),
                 Number(datapoint.value),
                 resolveUnit(metric.descriptor.unit),
                 StorageResolution.Standard

--- a/src/lib/telemetry/metric-naming.js
+++ b/src/lib/telemetry/metric-naming.js
@@ -10,15 +10,18 @@ const RENAMED_METRICS = [
 /**
  * Applies the non-production metric naming policy.
  *
- * In the production CDP environment (CDP_ENV === "prod") metric names are
- * returned unchanged. In every other (non-production) environment, the metrics
- * receive a .nonprod suffix
+ * Production naming is the default: metric names are returned unchanged unless
+ * the service is explicitly flagged as running in a lower environment (CDP_ENV
+ * set to a value other than "prod"), in which case the targeted metrics
+ * receive a .nonprod suffix. An unset or misconfigured CDP_ENV in production
+ * therefore leaves the metric names — and the alerts that target them —
+ * untouched.
  *
  * @param {string} name The metric name as recorded against the meter.
  * @returns {string} The name to emit for the current environment.
  */
 export function applyNonProductionMetricName(name) {
-  if (config.get('isCDPProduction')) {
+  if (!config.get('isLowerEnvironment')) {
     return name
   }
 

--- a/src/lib/telemetry/metric-naming.js
+++ b/src/lib/telemetry/metric-naming.js
@@ -10,12 +10,10 @@ const RENAMED_METRICS = [
 /**
  * Applies the non-production metric naming policy.
  *
- * Production naming is the default: metric names are returned unchanged unless
- * the service is explicitly flagged as running in a lower environment (CDP_ENV
- * set to a value other than "prod"), in which case the targeted metrics
- * receive a .nonprod suffix. An unset or misconfigured CDP_ENV in production
- * therefore leaves the metric names — and the alerts that target them —
- * untouched.
+ * Metric names are returned unchanged only in the production CDP environment
+ * (CDP_ENV === "prod"). Everywhere else — the lower environments, local
+ * development, and when CDP_ENV is absent — the targeted metrics receive a
+ * .nonprod suffix.
  *
  * @param {string} name The metric name as recorded against the meter.
  * @returns {string} The name to emit for the current environment.

--- a/src/lib/telemetry/metric-naming.js
+++ b/src/lib/telemetry/metric-naming.js
@@ -1,0 +1,32 @@
+import { config } from '../../config.js'
+
+const RENAMED_METRICS = [
+  'oracledb.healthcheck.',
+  'oracledb.connection.',
+  'oracledb.execution.time',
+  'request.latency.5XX'
+]
+
+/**
+ * Applies the non-production metric naming policy.
+ *
+ * In the production CDP environment (CDP_ENV === "prod") metric names are
+ * returned unchanged. In every other (non-production) environment, the metrics
+ * receive a .nonprod suffix
+ *
+ * @param {string} name The metric name as recorded against the meter.
+ * @returns {string} The name to emit for the current environment.
+ */
+export function applyNonProductionMetricName(name) {
+  if (config.get('isCDPProduction')) {
+    return name
+  }
+
+  const isRenamed = RENAMED_METRICS.some((prefix) => name.startsWith(prefix))
+
+  if (!isRenamed) {
+    return name
+  }
+
+  return `${name}.nonprod`
+}

--- a/src/lib/telemetry/metric-naming.test.js
+++ b/src/lib/telemetry/metric-naming.test.js
@@ -4,16 +4,16 @@ import { config } from '../../config.js'
 import { applyNonProductionMetricName } from './metric-naming.js'
 
 const original = {
-  isCDPProduction: config.get('isCDPProduction')
+  isLowerEnvironment: config.get('isLowerEnvironment')
 }
 
 afterEach(() => {
-  config.set('isCDPProduction', original.isCDPProduction)
+  config.set('isLowerEnvironment', original.isLowerEnvironment)
 })
 
 describe('applyNonProductionMetricName', () => {
-  test('returns names unchanged in the production CDP environment', () => {
-    config.set('isCDPProduction', true)
+  test('defaults to production naming when CDP_ENV is unset, protecting production alerts from a missing or misconfigured variable', () => {
+    expect(config.default('isLowerEnvironment')).toBe(false)
 
     expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
       'oracledb.healthcheck.status'
@@ -23,9 +23,20 @@ describe('applyNonProductionMetricName', () => {
     )
   })
 
-  describe('in a non-production CDP environment', () => {
+  test('returns names unchanged when not flagged as a lower environment', () => {
+    config.set('isLowerEnvironment', false)
+
+    expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
+      'oracledb.healthcheck.status'
+    )
+    expect(applyNonProductionMetricName('request.latency.5XX')).toBe(
+      'request.latency.5XX'
+    )
+  })
+
+  describe('in a lower (non-production) environment', () => {
     test('suffixes metrics whose name begins with a configured prefix', () => {
-      config.set('isCDPProduction', false)
+      config.set('isLowerEnvironment', true)
 
       expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
         'oracledb.healthcheck.status.nonprod'
@@ -36,7 +47,7 @@ describe('applyNonProductionMetricName', () => {
     })
 
     test('suffixes metrics whose name exactly matches a configured entry', () => {
-      config.set('isCDPProduction', false)
+      config.set('isLowerEnvironment', true)
 
       expect(applyNonProductionMetricName('oracledb.execution.time')).toBe(
         'oracledb.execution.time.nonprod'
@@ -47,7 +58,7 @@ describe('applyNonProductionMetricName', () => {
     })
 
     test('leaves non-targeted metrics unchanged', () => {
-      config.set('isCDPProduction', false)
+      config.set('isLowerEnvironment', true)
 
       expect(applyNonProductionMetricName('request.latency.2XX')).toBe(
         'request.latency.2XX'

--- a/src/lib/telemetry/metric-naming.test.js
+++ b/src/lib/telemetry/metric-naming.test.js
@@ -12,18 +12,18 @@ afterEach(() => {
 })
 
 describe('applyNonProductionMetricName', () => {
-  test('defaults to production naming when CDP_ENV is unset, protecting production alerts from a missing or misconfigured variable', () => {
-    expect(config.default('isLowerEnvironment')).toBe(false)
+  test('treats an absent CDP_ENV as a lower environment by default', () => {
+    expect(config.default('isLowerEnvironment')).toBe(true)
 
     expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
-      'oracledb.healthcheck.status'
+      'oracledb.healthcheck.status.nonprod'
     )
     expect(applyNonProductionMetricName('request.latency.5XX')).toBe(
-      'request.latency.5XX'
+      'request.latency.5XX.nonprod'
     )
   })
 
-  test('returns names unchanged when not flagged as a lower environment', () => {
+  test('returns names unchanged in the production environment (CDP_ENV=prod)', () => {
     config.set('isLowerEnvironment', false)
 
     expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(

--- a/src/lib/telemetry/metric-naming.test.js
+++ b/src/lib/telemetry/metric-naming.test.js
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from '@jest/globals'
+
+import { config } from '../../config.js'
+import { applyNonProductionMetricName } from './metric-naming.js'
+
+const original = {
+  isCDPProduction: config.get('isCDPProduction')
+}
+
+afterEach(() => {
+  config.set('isCDPProduction', original.isCDPProduction)
+})
+
+describe('applyNonProductionMetricName', () => {
+  test('returns names unchanged in the production CDP environment', () => {
+    config.set('isCDPProduction', true)
+
+    expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
+      'oracledb.healthcheck.status'
+    )
+    expect(applyNonProductionMetricName('request.latency.5XX')).toBe(
+      'request.latency.5XX'
+    )
+  })
+
+  describe('in a non-production CDP environment', () => {
+    test('suffixes metrics whose name begins with a configured prefix', () => {
+      config.set('isCDPProduction', false)
+
+      expect(applyNonProductionMetricName('oracledb.healthcheck.status')).toBe(
+        'oracledb.healthcheck.status.nonprod'
+      )
+      expect(applyNonProductionMetricName('oracledb.connection.time')).toBe(
+        'oracledb.connection.time.nonprod'
+      )
+    })
+
+    test('suffixes metrics whose name exactly matches a configured entry', () => {
+      config.set('isCDPProduction', false)
+
+      expect(applyNonProductionMetricName('oracledb.execution.time')).toBe(
+        'oracledb.execution.time.nonprod'
+      )
+      expect(applyNonProductionMetricName('request.latency.5XX')).toBe(
+        'request.latency.5XX.nonprod'
+      )
+    })
+
+    test('leaves non-targeted metrics unchanged', () => {
+      config.set('isCDPProduction', false)
+
+      expect(applyNonProductionMetricName('request.latency.2XX')).toBe(
+        'request.latency.2XX'
+      )
+      expect(applyNonProductionMetricName('request.latency.4XX')).toBe(
+        'request.latency.4XX'
+      )
+      expect(applyNonProductionMetricName('customersFindRequest')).toBe(
+        'customersFindRequest'
+      )
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DSFAAP-2543

Append a ".nonprod" suffix to the OracleDB and 5XX-latency gauges when running outside the production CDP environment, so the blanket-deployed Grafana alert configuration can target prod and non-prod as distinct series. Production metric names are unchanged.

Adds CDP_ENV / isCDPProduction config to distinguish real production (CDP_ENV=prod) from the lower environments, which all run with NODE_ENV=production.