### PR TITLE
Added timeout handling for JWKS fetch and added test

### DIFF
--- a/src/common/helpers/auth.test.js
+++ b/src/common/helpers/auth.test.js
@@ -600,4 +600,27 @@ describe('Auth Plugin (Full JWT Signature Verification)', () => {
 
     await freshServer.stop()
   })
+
+  test('rejects token when JWKS fetch times out (slow/blackhole endpoint)', async () => {
+    // A malicious or unreachable JWKS endpoint that never responds is aborted by the 5-second timeout in proxyFetch, preventing indefinite hangs.
+    const freshServer = await buildSecureServer()
+
+    msw.use(
+      http.get(`${ISSUER}${JWKS_PATH}`, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10000)) // 10s delay
+        return HttpResponse.json({ keys: [publicJwk] })
+      })
+    )
+
+    const res = await freshServer.inject({
+      method: 'GET',
+      url: '/secure',
+      headers: { authorization: `Bearer ${token}` }
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.result.message).toBe('Authentication failed')
+
+    await freshServer.stop()
+  })
 })

--- a/src/common/helpers/proxy/proxy-fetch.js
+++ b/src/common/helpers/proxy/proxy-fetch.js
@@ -1,15 +1,26 @@
 import { ProxyAgent } from 'undici'
 import { config } from '../../../config.js'
 
+/**
+ * Default timeout for JWKS fetch operations (in milliseconds)
+ */
+const JWKS_FETCH_TIMEOUT_MS = 5000
+
 export function proxyFetch(url, options) {
   const proxyUrlConfig = config.get('httpProxy') // bound to HTTP_PROXY
 
+  const timeoutSignal = AbortSignal.timeout(JWKS_FETCH_TIMEOUT_MS)
+  const signal = options?.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal
+
   if (!proxyUrlConfig) {
-    return fetch(url, options)
+    return fetch(url, { ...options, signal })
   }
 
   return fetch(url, {
     ...options,
+    signal,
     dispatcher: new ProxyAgent({
       uri: proxyUrlConfig,
       keepAliveTimeout: 10,


### PR DESCRIPTION
Adds a 5-second timeout to JWKS fetch operations to prevent authentication requests from hanging indefinitely when the JWKS endpoint is slow, unreachable, or malicious