### PR TITLE
Added security headers plugin and tests for response headers

### DIFF
--- a/src/common/helpers/security-headers.js
+++ b/src/common/helpers/security-headers.js
@@ -1,0 +1,72 @@
+/**
+ * @typedef {import('@hapi/hapi').Server} Server
+ * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').ResponseToolkit} ResponseToolkit
+ */
+
+/**
+ * Hapi plugin that adds comprehensive security headers to all responses.
+ 
+ * Headers added:
+ * - Content-Security-Policy: Strict policy for API routes only
+ * - Cache-Control: no-store (API routes only, to prevent caching of PII)
+ * - Pragma: no-cache (API routes only)
+ * - Referrer-Policy: no-referrer (all routes)
+ * - Cross-Origin-Opener-Policy: same-origin (all routes)
+ * - Cross-Origin-Resource-Policy: same-origin (all routes)
+ * - Permissions-Policy: Disables camera, microphone, geolocation, browsing-topics (all routes)
+ *
+ * This plugin complements the security headers already set by Hapi's routes.security configuration (HSTS, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection).
+ */
+export const securityHeaders = {
+  plugin: {
+    name: 'securityHeaders',
+    version: '0.0.0',
+    /**
+     * @param {Server} server
+     */
+    register: (server) => {
+      server.ext('onPreResponse', (request, h) => {
+        const { response } = request
+
+        const headers = response.isBoom
+          ? response.output.headers
+          : response.headers
+
+        /**
+         * Helper function to set a header value (lowercase for Boom compatibility)
+         * @param {string} key - Header name
+         * @param {string} value - Header value
+         */
+        const set = (key, value) => {
+          headers[key.toLowerCase()] = value
+        }
+
+        // Headers applied to all routes
+        set('Referrer-Policy', 'no-referrer')
+        set('Cross-Origin-Opener-Policy', 'same-origin')
+        set('Cross-Origin-Resource-Policy', 'same-origin')
+        set(
+          'Permissions-Policy',
+          'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+        )
+
+        const path = request.path || ''
+        const isDocs =
+          path.startsWith('/documentation') || path.startsWith('/swaggerui')
+
+        // For non-documentation routes (API routes), apply additional strict headers
+        if (!isDocs) {
+          set(
+            'Content-Security-Policy',
+            "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+          )
+          set('Cache-Control', 'no-store')
+          set('Pragma', 'no-cache')
+        }
+
+        return h.continue
+      })
+    }
+  }
+}

--- a/src/common/helpers/security-headers.test.js
+++ b/src/common/helpers/security-headers.test.js
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals'
+import Hapi from '@hapi/hapi'
+import Boom from '@hapi/boom'
+
+import { securityHeaders } from './security-headers.js'
+
+/**
+ * @typedef {import('@hapi/hapi').Server} Server
+ */
+
+describe('securityHeaders plugin', () => {
+  /** @type {Server} */
+  let server
+
+  beforeAll(async () => {
+    server = Hapi.server({ port: 0 })
+    await server.register(securityHeaders)
+
+    server.route([
+      {
+        method: 'GET',
+        path: '/api/test',
+        handler: () => ({ data: 'test' })
+      },
+      {
+        method: 'GET',
+        path: '/api/error',
+        handler: () => {
+          throw Boom.badRequest('Invalid request')
+        }
+      },
+      {
+        method: 'GET',
+        path: '/documentation/scalar',
+        handler: (_request, h) => h.response('<html></html>').type('text/html')
+      },
+      {
+        method: 'GET',
+        path: '/swaggerui/assets/file.js',
+        handler: (_request, h) => h.response('/* code */').type('text/js')
+      }
+    ])
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  test('API routes receive all security headers', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/test' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['referrer-policy']).toBe('no-referrer')
+    expect(res.headers['cross-origin-opener-policy']).toBe('same-origin')
+    expect(res.headers['cross-origin-resource-policy']).toBe('same-origin')
+    expect(res.headers['permissions-policy']).toBe(
+      'camera=(), microphone=(), geolocation=(), browsing-topics=()'
+    )
+    expect(res.headers['content-security-policy']).toBe(
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+    )
+    expect(res.headers['cache-control']).toBe('no-store')
+    expect(res.headers['pragma']).toBe('no-cache')
+  })
+
+  test('error responses receive all security headers', async () => {
+    const res = await server.inject({ method: 'GET', url: '/api/error' })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.headers['content-security-policy']).toBe(
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+    )
+    expect(res.headers['cache-control']).toBe('no-store')
+    expect(res.headers['pragma']).toBe('no-cache')
+  })
+
+  test('documentation routes omit CSP and strict cache headers', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/documentation/scalar'
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['referrer-policy']).toBe('no-referrer')
+    expect(res.headers['cross-origin-opener-policy']).toBe('same-origin')
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['pragma']).toBeUndefined()
+    expect(res.headers['cache-control']).not.toBe('no-store')
+  })
+
+  test('swaggerui routes omit CSP and strict cache headers', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/swaggerui/assets/file.js'
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['pragma']).toBeUndefined()
+    expect(res.headers['cache-control']).not.toBe('no-store')
+  })
+})

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ import { authPlugin } from './common/helpers/auth.js'
 import { piiContextPlugin } from './common/helpers/pii-context.js'
 import { clientScopesPlugin } from './common/helpers/client-scopes.js'
 import { loadClients } from './lib/clients/load.js'
+import { securityHeaders } from './common/helpers/security-headers.js'
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
@@ -56,9 +57,9 @@ async function createServer() {
         hsts: {
           maxAge: 31536000,
           includeSubDomains: true,
-          preload: false
+          preload: true
         },
-        xss: 'enabled',
+        xss: 'disabled',
         noSniff: true,
         xframe: true
       }
@@ -104,6 +105,11 @@ async function createServer() {
      * and downstream extensions observe the normalised status code.
      */
     errorEnvelope,
+    /**
+     * adds comprehensive security headers to all responses (both successful
+     * and error responses) via onPreResponse extension
+     */
+    securityHeaders,
     /**
      * authenticates incoming requests using JWT tokens with signature verification
      */


### PR DESCRIPTION
- Implemented as a Hapi plugin using onPreResponse extension
- Added headers to both successful and error (Boom) responses

**Security Headers Added**

**All Routes:**
- Referrer-Policy: no-referrer
- Cross-Origin-Opener-Policy: same-origin
- Cross-Origin-Resource-Policy: same-origin
- Permissions-Policy: camera=(), microphone=(), geolocation=(), browsing-topics=()

**API Routes Only (excludes /documentation and /swaggerui):**
- Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'
- Cache-Control: no-store (prevents caching of PII)
- Pragma: no-cache

**Updated Hapi Security Config:**
- X-XSS-Protection: 0 (disabled per current OWASP guidance)
- Strict-Transport-Security: max-age=31536000; includeSubDomains; preload

<img width="1706" height="554" alt="image" src="https://github.com/user-attachments/assets/b9d86a17-4c43-4761-aba7-a79d0b210d36" />
