### PR TITLE
Implement per-client rate limiting with Redis support

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,9 +13,8 @@ AUTH_ALLOWED_ISSUERS=https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_uVM3W
 # Feature Flags
 CASE_MANAGEMENT_ENABLED=true
 
-# Per-client rate limiting: 10 requests/second with burst of 20
-RATE_LIMIT_RATE_PER_SECOND=10
-RATE_LIMIT_BURST_LIMIT=20
+# Per-client rate limiting: 20 requests per 1 second
+RATE_LIMIT_POINTS=20
 RATE_LIMIT_DURATION=1
 
 REDIS_HOST=127.0.0.1

--- a/.env.development
+++ b/.env.development
@@ -13,3 +13,10 @@ AUTH_ALLOWED_ISSUERS=https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_uVM3W
 # Feature Flags
 CASE_MANAGEMENT_ENABLED=true
 
+# Per-client rate limiting: 10 requests/second with burst of 20
+RATE_LIMIT_RATE_PER_SECOND=10
+RATE_LIMIT_BURST_LIMIT=20
+RATE_LIMIT_DURATION=1
+
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379

--- a/.env.development
+++ b/.env.development
@@ -13,8 +13,8 @@ AUTH_ALLOWED_ISSUERS=https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_uVM3W
 # Feature Flags
 CASE_MANAGEMENT_ENABLED=true
 
-# Per-client rate limiting: 20 requests per 1 second
-RATE_LIMIT_POINTS=20
+# Per-client rate limiting: 10 requests per 1 second
+RATE_LIMIT_POINTS=10
 RATE_LIMIT_DURATION=1
 
 REDIS_HOST=127.0.0.1

--- a/compose.yml
+++ b/compose.yml
@@ -24,9 +24,18 @@ services:
 
   redis:
     image: redis:7.2.3-alpine3.18
+    command: --save 60 1 --loglevel warning
     ports:
       - '6379:6379'
-    restart: always
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep PONG']
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 3s
+    volumes:
+      - redis-data:/data
     networks:
       - cdp-tenant
 
@@ -74,11 +83,14 @@ services:
     links:
       - 'localstack:localstack'
       - 'mongodb:mongodb'
+      - 'redis:redis'
     depends_on:
       localstack:
         condition: service_healthy
       mongodb:
         condition: service_started
+      redis:
+        condition: service_healthy
     env_file:
       - 'compose/aws.env'
     environment:
@@ -86,6 +98,7 @@ services:
       NODE_ENV: development
       LOCALSTACK_ENDPOINT: http://localstack:4566
       MONGO_URI: mongodb://mongodb:27017/
+      REDIS_HOST: redis
     networks:
       - cdp-tenant
     volumes:
@@ -95,6 +108,7 @@ services:
 ################################################################################
 
 volumes:
+  redis-data:
   mongodb-data:
 
 networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,20 @@ include:
     service: oracledb
 
 services:
+  redis:
+    image: redis:7.2.3-alpine3.18
+    command: --save 60 1 --loglevel warning
+    ports:
+      - '6379:6379'
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep PONG']
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 3s
+    volumes:
+      - redis-data:/data
   mongodb:
     image: mongo:6.0.13
     ports:
@@ -16,5 +30,7 @@ services:
     restart: always
 
 volumes:
+  redis-data:
+    name: redis-data
   mongodb-data:
     name: mongodb-data

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "dotenv": "16.5.0",
         "eslint": "9.28.0",
         "husky": "9.1.7",
+        "ioredis-mock": "8.9.0",
         "jest": "29.7.0",
         "msw": "2.10.2",
         "neostandard": "0.12.1",
@@ -3391,6 +3392,13 @@
         }
       }
     },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
@@ -6214,6 +6222,17 @@
       "license": "MIT",
       "dependencies": {
         "hapi-pino": "*"
+      }
+    },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.7.tgz",
+      "integrity": "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ioredis": ">=5"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -9321,6 +9340,35 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fengari": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.4.tgz",
+      "integrity": "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -10350,6 +10398,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.9.0.tgz",
+      "integrity": "sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.2.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
+      }
+    },
+    "node_modules/ioredis-mock/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -13965,6 +14047,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -15198,6 +15290,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "hapi-pulse": "3.0.1",
         "hapi-swagger": "17.3.2",
         "https-proxy-agent": "9.0.0",
+        "ioredis": "5.4.2",
         "joi": "17.13.3",
         "jose": "6.2.3",
         "jsonc-parser": "3.3.1",
@@ -46,6 +47,7 @@
         "oracledb": "6.10.0",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
+        "rate-limiter-flexible": "11.2.0",
         "undici": "8.3.0"
       },
       "devDependencies": {
@@ -3388,6 +3390,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -7872,6 +7880,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8192,6 +8209,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -10302,6 +10328,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.2.tgz",
+      "integrity": "sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -11891,11 +11941,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
@@ -13862,6 +13924,12 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/rate-limiter-flexible": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-11.2.0.tgz",
+      "integrity": "sha512-L0eIK+BmFMi6NcvmtEg7RSswOFKi9MMD5RhBIypFfOve+G6Jl1Xbb8qEHgK3uRzNtkOFYF0L9f7P4rSf2PnUVw==",
+      "license": "ISC"
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -13916,6 +13984,27 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14654,6 +14743,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "hapi-pulse": "3.0.1",
     "hapi-swagger": "17.3.2",
     "https-proxy-agent": "9.0.0",
+    "ioredis": "5.4.2",
     "joi": "17.13.3",
     "jose": "6.2.3",
     "jsonc-parser": "3.3.1",
@@ -66,6 +67,7 @@
     "oracledb": "6.10.0",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
+    "rate-limiter-flexible": "11.2.0",
     "undici": "8.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "dotenv": "16.5.0",
     "eslint": "9.28.0",
     "husky": "9.1.7",
+    "ioredis-mock": "8.9.0",
     "jest": "29.7.0",
     "msw": "2.10.2",
     "neostandard": "0.12.1",

--- a/src/common/helpers/rate-limit.js
+++ b/src/common/helpers/rate-limit.js
@@ -31,7 +31,7 @@ export const rateLimitPlugin = {
     )
 
     server.logger?.info(
-      `Rate limiting enabled: ${rateLimitConfig.burstLimit} requests per client`
+      `Rate limiting enabled: ${rateLimitConfig.points} requests per ${rateLimitConfig.duration}s per client`
     )
 
     server.ext('onPreHandler', async (request, h) => {
@@ -49,7 +49,7 @@ export const rateLimitPlugin = {
 
         request.app.rateLimit = {
           result,
-          limit: rateLimitConfig.burstLimit,
+          limit: rateLimitConfig.points,
           exceeded: false
         }
 
@@ -57,7 +57,7 @@ export const rateLimitPlugin = {
       } catch (rateLimitResult) {
         request.app.rateLimit = {
           result: rateLimitResult,
-          limit: rateLimitConfig.burstLimit,
+          limit: rateLimitConfig.points,
           exceeded: true
         }
 
@@ -117,8 +117,7 @@ export const rateLimitPlugin = {
 
 /**
  * @param {object} rateLimitConfig - Rate limit configuration
- * @param {number} rateLimitConfig.burstLimit
- * @param {number} rateLimitConfig.ratePerSecond
+ * @param {number} rateLimitConfig.points
  * @param {number} rateLimitConfig.duration
  * @param {object} redisConfig - Redis configuration
  * @param {string} redisConfig.host
@@ -138,7 +137,7 @@ async function createLimiter(rateLimitConfig, redisConfig, logger) {
   if (isTest) {
     logger?.info('Using in-memory rate limiter for tests')
     return new RateLimiterMemory({
-      points: rateLimitConfig.burstLimit,
+      points: rateLimitConfig.points,
       duration: rateLimitConfig.duration,
       blockDuration: 0
     })
@@ -177,7 +176,7 @@ async function createLimiter(rateLimitConfig, redisConfig, logger) {
 
     return new RateLimiterRedis({
       storeClient: redisClient,
-      points: rateLimitConfig.burstLimit,
+      points: rateLimitConfig.points,
       duration: rateLimitConfig.duration,
       blockDuration: 0,
       keyPrefix: redisConfig.keyPrefix
@@ -188,7 +187,7 @@ async function createLimiter(rateLimitConfig, redisConfig, logger) {
       'Failed to connect to Redis, falling back to in-memory rate limiter'
     )
     return new RateLimiterMemory({
-      points: rateLimitConfig.burstLimit,
+      points: rateLimitConfig.points,
       duration: rateLimitConfig.duration,
       blockDuration: 0
     })

--- a/src/common/helpers/rate-limit.js
+++ b/src/common/helpers/rate-limit.js
@@ -1,0 +1,238 @@
+/**
+ * @typedef {object} RateLimitInfo
+ * @property {import('rate-limiter-flexible').RateLimiterRes} result - Rate limiter result
+ * @property {number} limit - Maximum requests allowed
+ * @property {boolean} exceeded - Whether rate limit was exceeded
+ */
+
+import Boom from '@hapi/boom'
+import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible'
+import IORedis from 'ioredis'
+
+import { config } from '../../config.js'
+
+/**
+ * @type {import('@hapi/hapi').Plugin<void>}
+ */
+export const rateLimitPlugin = {
+  name: 'rate-limit',
+  version: '1.0.0',
+
+  register: async function (server) {
+    const rateLimitConfig = config.get('rateLimit')
+    const redisConfig = config.get('redis')
+
+    const exemptPaths = ['/health']
+
+    const limiter = await createLimiter(
+      rateLimitConfig,
+      redisConfig,
+      server.logger
+    )
+
+    server.logger?.info(
+      `Rate limiting enabled: ${rateLimitConfig.burstLimit} requests per client`
+    )
+
+    server.ext('onPreHandler', async (request, h) => {
+      const { path } = request
+
+      // Skip rate limiting for exempt paths
+      if (exemptPaths.some((p) => path.startsWith(p))) {
+        return h.continue
+      }
+
+      const key = getClientKey(request)
+
+      try {
+        const result = await limiter.consume(key, 1)
+
+        request.app.rateLimit = {
+          result,
+          limit: rateLimitConfig.burstLimit,
+          exceeded: false
+        }
+
+        return h.continue
+      } catch (rateLimitResult) {
+        request.app.rateLimit = {
+          result: rateLimitResult,
+          limit: rateLimitConfig.burstLimit,
+          exceeded: true
+        }
+
+        throw Boom.tooManyRequests('Rate limit exceeded')
+      }
+    })
+
+    server.ext('onPreResponse', (request, h) => {
+      const rateLimitInfo = request.app.rateLimit
+
+      if (!rateLimitInfo) {
+        return h.continue
+      }
+
+      const response = request.response
+
+      if (!response) {
+        return h.continue
+      }
+
+      const { result, limit, exceeded } = rateLimitInfo
+
+      // Calculate header values
+      const remaining = Math.max(0, result.remainingPoints ?? 0)
+      const reset = getRateLimitResetTime(result.msBeforeNext)
+
+      // Handle both Boom errors and regular responses
+      if (response.isBoom) {
+        response.output.headers['X-RateLimit-Limit'] = String(limit)
+        response.output.headers['X-RateLimit-Remaining'] = String(remaining)
+        response.output.headers['X-RateLimit-Reset'] = String(reset)
+
+        if (exceeded) {
+          response.output.headers['Retry-After'] = String(
+            getRetryAfterSeconds(result.msBeforeNext)
+          )
+        }
+      } else if (typeof response.header === 'function') {
+        response.header('X-RateLimit-Limit', String(limit))
+        response.header('X-RateLimit-Remaining', String(remaining))
+        response.header('X-RateLimit-Reset', String(reset))
+
+        if (exceeded) {
+          response.header(
+            'Retry-After',
+            String(getRetryAfterSeconds(result.msBeforeNext))
+          )
+        }
+      }
+
+      return h.continue
+    })
+
+    server.logger?.info('Rate limiting plugin registered successfully')
+  }
+}
+
+/**
+ * @param {object} rateLimitConfig - Rate limit configuration
+ * @param {number} rateLimitConfig.burstLimit
+ * @param {number} rateLimitConfig.ratePerSecond
+ * @param {number} rateLimitConfig.duration
+ * @param {object} redisConfig - Redis configuration
+ * @param {string} redisConfig.host
+ * @param {number} redisConfig.port
+ * @param {string} redisConfig.username
+ * @param {string} redisConfig.password
+ * @param {string} redisConfig.keyPrefix
+ * @param {boolean} redisConfig.useSingleInstanceCache
+ * @param {boolean} redisConfig.useTLS
+ * @param {number} redisConfig.db
+ * @param {object} [logger] - Optional logger instance
+ */
+async function createLimiter(rateLimitConfig, redisConfig, logger) {
+  const isTest = process.env.NODE_ENV === 'test'
+
+  // Use in-memory limiter for tests, Redis for production/development
+  if (isTest) {
+    logger?.info('Using in-memory rate limiter for tests')
+    return new RateLimiterMemory({
+      points: rateLimitConfig.burstLimit,
+      duration: rateLimitConfig.duration,
+      blockDuration: 0
+    })
+  }
+
+  try {
+    const Redis = IORedis.default || IORedis
+    const redisClient = new Redis({
+      host: redisConfig.host,
+      port: redisConfig.port,
+      username: redisConfig.username || undefined,
+      password: redisConfig.password || undefined,
+      db: redisConfig.db || 0,
+      tls: redisConfig.useTLS ? {} : undefined,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 3,
+      retryStrategy: (times) => {
+        if (times > 3) {
+          logger?.error('Redis connection failed after 3 retries')
+          return null
+        }
+        const delay = Math.min(times * 100, 2000)
+        return delay
+      }
+    })
+
+    // Test the connection
+    await redisClient.ping()
+    logger?.info(
+      `Connected to Redis at ${redisConfig.host}:${redisConfig.port}`
+    )
+
+    redisClient.on('error', (err) => {
+      logger?.error({ err }, 'Redis client error')
+    })
+
+    return new RateLimiterRedis({
+      storeClient: redisClient,
+      points: rateLimitConfig.burstLimit,
+      duration: rateLimitConfig.duration,
+      blockDuration: 0,
+      keyPrefix: redisConfig.keyPrefix
+    })
+  } catch (error) {
+    logger?.error(
+      { err: error },
+      'Failed to connect to Redis, falling back to in-memory rate limiter'
+    )
+    return new RateLimiterMemory({
+      points: rateLimitConfig.burstLimit,
+      duration: rateLimitConfig.duration,
+      blockDuration: 0
+    })
+  }
+}
+
+/**
+ * Extract the client key for rate limiting from the request
+ * Priority: client_id from JWT > credentials.id > IP address
+ * @param {import('@hapi/hapi').Request} request
+ */
+function getClientKey(request) {
+  let key = request.info.remoteAddress
+
+  // Check for client_id in JWT artifacts (real auth plugin)
+  if (
+    request.auth.artifacts &&
+    typeof request.auth.artifacts.client_id === 'string'
+  ) {
+    key = request.auth.artifacts.client_id
+  }
+  // Fallback to credentials.id (for mock auth in tests)
+  else if (
+    request.auth.credentials &&
+    typeof request.auth.credentials.id === 'string'
+  ) {
+    key = request.auth.credentials.id
+  }
+
+  return key
+}
+
+/**
+ * @param {number} msBeforeNext
+ * @returns {number} Unix timestamp
+ */
+function getRateLimitResetTime(msBeforeNext) {
+  return Math.ceil((Date.now() + Math.max(0, msBeforeNext || 0)) / 1000)
+}
+
+/**
+ * @param {number} msBeforeNext
+ * @returns {number} Seconds to wait
+ */
+function getRetryAfterSeconds(msBeforeNext) {
+  return Math.ceil(Math.max(0, msBeforeNext || 0) / 1000)
+}

--- a/src/common/helpers/rate-limit.js
+++ b/src/common/helpers/rate-limit.js
@@ -7,9 +7,9 @@
 
 import Boom from '@hapi/boom'
 import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible'
-import IORedis from 'ioredis'
 
 import { config } from '../../config.js'
+import { buildRedisClient } from './redis-client.js'
 
 /**
  * @type {import('@hapi/hapi').Plugin<void>}
@@ -144,35 +144,10 @@ async function createLimiter(rateLimitConfig, redisConfig, logger) {
   }
 
   try {
-    const Redis = IORedis.default || IORedis
-    const redisClient = new Redis({
-      host: redisConfig.host,
-      port: redisConfig.port,
-      username: redisConfig.username || undefined,
-      password: redisConfig.password || undefined,
-      db: redisConfig.db || 0,
-      tls: redisConfig.useTLS ? {} : undefined,
-      enableOfflineQueue: false,
-      maxRetriesPerRequest: 3,
-      retryStrategy: (times) => {
-        if (times > 3) {
-          logger?.error('Redis connection failed after 3 retries')
-          return null
-        }
-        const delay = Math.min(times * 100, 2000)
-        return delay
-      }
-    })
+    const redisClient = buildRedisClient(redisConfig, logger)
 
     // Test the connection
     await redisClient.ping()
-    logger?.info(
-      `Connected to Redis at ${redisConfig.host}:${redisConfig.port}`
-    )
-
-    redisClient.on('error', (err) => {
-      logger?.error({ err }, 'Redis client error')
-    })
 
     return new RateLimiterRedis({
       storeClient: redisClient,

--- a/src/common/helpers/rate-limit.test.js
+++ b/src/common/helpers/rate-limit.test.js
@@ -1,0 +1,170 @@
+import Hapi from '@hapi/hapi'
+import { describe, beforeEach, afterEach, test, expect } from '@jest/globals'
+
+import { rateLimitPlugin } from './rate-limit.js'
+import { config } from '../../config.js'
+
+const CLIENT_ID = 'test-client-123'
+const CLIENT_ID_2 = 'test-client-456'
+const burstLimit = config.get('rateLimit').burstLimit
+
+const mockAuthPlugin = {
+  name: 'mock-auth',
+  version: '1.0.0',
+  register: async function (server) {
+    server.auth.scheme('mock', () => ({
+      authenticate: async (request, h) => {
+        const authHeader = request.headers.authorization
+        if (!authHeader?.startsWith('Bearer ')) {
+          throw new Error('Missing or invalid authorization header')
+        }
+
+        const token = authHeader.substring(7)
+        const clientId = token.startsWith('client:')
+          ? token.substring(7)
+          : CLIENT_ID
+
+        return h.authenticated({
+          credentials: { id: clientId, client_id: clientId }
+        })
+      }
+    }))
+
+    server.auth.strategy('default', 'mock')
+    server.auth.default('default')
+  }
+}
+
+describe('Rate Limit Plugin', () => {
+  let server
+
+  beforeEach(async () => {
+    server = Hapi.server()
+    await server.register({ plugin: mockAuthPlugin })
+    await server.register({ plugin: rateLimitPlugin })
+
+    server.route([
+      {
+        method: 'GET',
+        path: '/health',
+        options: { auth: false, handler: () => ({ status: 'ok' }) }
+      },
+      {
+        method: 'GET',
+        path: '/api/test',
+        handler: () => ({ message: 'success' })
+      }
+    ])
+
+    await server.initialize()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('allows requests under the rate limit', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID}` }
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['x-ratelimit-limit']).toBe(String(burstLimit))
+    expect(res.headers['x-ratelimit-remaining']).toBe(String(burstLimit - 1))
+    expect(res.headers['x-ratelimit-reset']).toBeDefined()
+  })
+
+  test('blocks requests exceeding the rate limit', async () => {
+    // Exhaust the limit
+    for (let i = 0; i < burstLimit; i++) {
+      await server.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: { authorization: `Bearer client:${CLIENT_ID}` }
+      })
+    }
+
+    // Should be blocked
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID}` }
+    })
+
+    expect(res.statusCode).toBe(429)
+    expect(res.result.message).toMatch(/rate limit exceeded/i)
+    expect(res.headers['retry-after']).toBeDefined()
+    expect(res.headers['x-ratelimit-remaining']).toBe('0')
+  })
+
+  test('includes all required headers', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID}` }
+    })
+
+    expect(res.headers['x-ratelimit-limit']).toBeDefined()
+    expect(res.headers['x-ratelimit-remaining']).toBeDefined()
+    expect(res.headers['x-ratelimit-reset']).toBeDefined()
+  })
+
+  test('includes Retry-After header when rate limited', async () => {
+    // Exhaust the limit
+    for (let i = 0; i < burstLimit; i++) {
+      await server.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: { authorization: `Bearer client:${CLIENT_ID}` }
+      })
+    }
+
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID}` }
+    })
+
+    expect(res.statusCode).toBe(429)
+    expect(res.headers['retry-after']).toBeDefined()
+  })
+
+  test('rate limits are applied per client', async () => {
+    // Exhaust limit for client 1
+    for (let i = 0; i < burstLimit; i++) {
+      await server.inject({
+        method: 'GET',
+        url: '/api/test',
+        headers: { authorization: `Bearer client:${CLIENT_ID}` }
+      })
+    }
+
+    // Client 1 should be blocked
+    const res1 = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID}` }
+    })
+    expect(res1.statusCode).toBe(429)
+
+    // Client 2 should still work
+    const res2 = await server.inject({
+      method: 'GET',
+      url: '/api/test',
+      headers: { authorization: `Bearer client:${CLIENT_ID_2}` }
+    })
+    expect(res2.statusCode).toBe(200)
+  })
+
+  test('/health endpoint is exempt from rate limiting', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/health'
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['x-ratelimit-limit']).toBeUndefined()
+  })
+})

--- a/src/common/helpers/rate-limit.test.js
+++ b/src/common/helpers/rate-limit.test.js
@@ -6,7 +6,7 @@ import { config } from '../../config.js'
 
 const CLIENT_ID = 'test-client-123'
 const CLIENT_ID_2 = 'test-client-456'
-const burstLimit = config.get('rateLimit').burstLimit
+const points = config.get('rateLimit').points
 
 const mockAuthPlugin = {
   name: 'mock-auth',
@@ -71,14 +71,14 @@ describe('Rate Limit Plugin', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.headers['x-ratelimit-limit']).toBe(String(burstLimit))
-    expect(res.headers['x-ratelimit-remaining']).toBe(String(burstLimit - 1))
+    expect(res.headers['x-ratelimit-limit']).toBe(String(points))
+    expect(res.headers['x-ratelimit-remaining']).toBe(String(points - 1))
     expect(res.headers['x-ratelimit-reset']).toBeDefined()
   })
 
   test('blocks requests exceeding the rate limit', async () => {
     // Exhaust the limit
-    for (let i = 0; i < burstLimit; i++) {
+    for (let i = 0; i < points; i++) {
       await server.inject({
         method: 'GET',
         url: '/api/test',
@@ -113,7 +113,7 @@ describe('Rate Limit Plugin', () => {
 
   test('includes Retry-After header when rate limited', async () => {
     // Exhaust the limit
-    for (let i = 0; i < burstLimit; i++) {
+    for (let i = 0; i < points; i++) {
       await server.inject({
         method: 'GET',
         url: '/api/test',
@@ -133,7 +133,7 @@ describe('Rate Limit Plugin', () => {
 
   test('rate limits are applied per client', async () => {
     // Exhaust limit for client 1
-    for (let i = 0; i < burstLimit; i++) {
+    for (let i = 0; i < points; i++) {
       await server.inject({
         method: 'GET',
         url: '/api/test',

--- a/src/common/helpers/redis-client.js
+++ b/src/common/helpers/redis-client.js
@@ -1,0 +1,71 @@
+import IORedis from 'ioredis'
+
+const { default: Redis, Cluster } = IORedis
+
+/**
+ * Creates a Redis client (single instance or cluster) based on configuration
+ *
+ * @param {object} redisConfig - Redis configuration object
+ * @param {string} redisConfig.host - Redis host
+ * @param {number} redisConfig.port - Redis port
+ * @param {number} [redisConfig.db] - Redis database number
+ * @param {string} [redisConfig.keyPrefix] - Key prefix for all keys
+ * @param {string} [redisConfig.username] - Redis username (ACL)
+ * @param {string} [redisConfig.password] - Redis password
+ * @param {boolean} [redisConfig.useTLS] - Use TLS connection
+ * @param {boolean} [redisConfig.useSingleInstanceCache] - Use single instance vs cluster
+ * @param {object} [logger] - logger instance
+ * @returns {IORedis.Redis | IORedis.Cluster} Redis client instance
+ */
+export function buildRedisClient(redisConfig, logger) {
+  const port = redisConfig.port ?? 6379
+  const db = redisConfig.db ?? 0
+  const keyPrefix = redisConfig.keyPrefix
+  const host = redisConfig.host
+
+  const credentials =
+    redisConfig.username === '' || !redisConfig.username
+      ? {}
+      : {
+          username: redisConfig.username,
+          password: redisConfig.password
+        }
+
+  const tls = redisConfig.useTLS ? { tls: {} } : {}
+
+  let redisClient
+
+  if (redisConfig.useSingleInstanceCache) {
+    redisClient = new Redis({
+      port,
+      host,
+      db,
+      keyPrefix,
+      enableReadyCheck: false,
+      ...credentials,
+      ...tls
+    })
+  } else {
+    redisClient = new Cluster([{ host, port }], {
+      keyPrefix,
+      slotsRefreshTimeout: 10000,
+      dnsLookup: (address, callback) => callback(null, address),
+      redisOptions: {
+        enableReadyCheck: false,
+        db,
+        ...credentials,
+        ...tls
+      }
+    })
+  }
+
+  redisClient.on('connect', () => {
+    logger?.info(`Connected to Redis server at ${host}:${port}`)
+  })
+
+  redisClient.on('error', (error) => {
+    logger?.error({ err: error }, 'Redis connection error')
+  })
+
+  return redisClient
+}

--- a/src/common/helpers/redis-client.test.js
+++ b/src/common/helpers/redis-client.test.js
@@ -1,0 +1,210 @@
+import { describe, beforeEach, test, expect } from '@jest/globals'
+import { buildRedisClient } from './redis-client.js'
+
+describe('buildRedisClient', () => {
+  let mockLogger
+
+  beforeEach(() => {
+    mockLogger = {
+      info: () => {},
+      error: () => {}
+    }
+  })
+
+  test('creates single instance Redis client with minimal config', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.port).toBe(6379)
+    expect(client.options.host).toBe('127.0.0.1')
+  })
+
+  test('creates single instance Redis client with full config', () => {
+    const config = {
+      host: 'redis.example.com',
+      port: 6380,
+      db: 2,
+      keyPrefix: 'test-prefix:',
+      username: 'testuser',
+      password: 'testpass',
+      useTLS: false,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.port).toBe(6380)
+    expect(client.options.host).toBe('redis.example.com')
+    expect(client.options.db).toBe(2)
+    expect(client.options.keyPrefix).toBe('test-prefix:')
+    expect(client.options.username).toBe('testuser')
+    expect(client.options.password).toBe('testpass')
+  })
+
+  test('creates single instance Redis client with TLS enabled', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useTLS: true,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.tls).toBeDefined()
+  })
+
+  test('creates single instance Redis client without TLS when disabled', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useTLS: false,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.tls).toBeUndefined()
+  })
+
+  test('creates cluster Redis client when useSingleInstanceCache is false', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      keyPrefix: 'cluster-prefix:',
+      useSingleInstanceCache: false
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    // Cluster client has different structure
+    expect(client.options).toBeDefined()
+    expect(client.options.keyPrefix).toBe('cluster-prefix:')
+  })
+
+  test('creates cluster Redis client with credentials', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      username: 'clusteruser',
+      password: 'clusterpass',
+      db: 1,
+      useSingleInstanceCache: false
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.redisOptions.username).toBe('clusteruser')
+    expect(client.options.redisOptions.password).toBe('clusterpass')
+    expect(client.options.redisOptions.db).toBe(1)
+  })
+
+  test('creates cluster Redis client with TLS', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useTLS: true,
+      useSingleInstanceCache: false
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.redisOptions.tls).toBeDefined()
+  })
+
+  test('handles empty username by omitting credentials', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      username: '',
+      password: 'somepass',
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    // ioredis sets undefined values to null
+    expect(client.options.username).toBeFalsy()
+    expect(client.options.password).toBeFalsy()
+  })
+
+  test('handles undefined username by omitting credentials', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      password: 'somepass',
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    // ioredis sets undefined values to null
+    expect(client.options.username).toBeFalsy()
+    expect(client.options.password).toBeFalsy()
+  })
+
+  test('uses default port 6379 when port is not specified', () => {
+    const config = {
+      host: '127.0.0.1',
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.port).toBe(6379)
+  })
+
+  test('uses default db 0 when db is not specified', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.options.db).toBe(0)
+  })
+
+  test('works without logger', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config)
+
+    expect(client).toBeDefined()
+  })
+
+  test('sets up event handlers for connect and error', () => {
+    const config = {
+      host: '127.0.0.1',
+      port: 6379,
+      useSingleInstanceCache: true
+    }
+
+    const client = buildRedisClient(config, mockLogger)
+
+    expect(client).toBeDefined()
+    expect(client.listenerCount('connect')).toBeGreaterThan(0)
+    expect(client.listenerCount('error')).toBeGreaterThan(0)
+  })
+})

--- a/src/common/helpers/redis-client.test.js
+++ b/src/common/helpers/redis-client.test.js
@@ -1,14 +1,29 @@
-import { describe, beforeEach, test, expect } from '@jest/globals'
+import { describe, beforeEach, afterEach, test, expect } from '@jest/globals'
 import { buildRedisClient } from './redis-client.js'
 
 describe('buildRedisClient', () => {
   let mockLogger
+  const createdClients = []
 
   beforeEach(() => {
     mockLogger = {
       info: () => {},
       error: () => {}
     }
+  })
+
+  afterEach(async () => {
+    // Disconnect all created Redis clients to prevent hanging
+    await Promise.all(
+      createdClients.map(async (client) => {
+        try {
+          await client.disconnect()
+        } catch (error) {
+          // Ignore errors during cleanup
+        }
+      })
+    )
+    createdClients.length = 0
   })
 
   test('creates single instance Redis client with minimal config', () => {
@@ -19,6 +34,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.port).toBe(6379)
@@ -38,6 +54,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.port).toBe(6380)
@@ -57,6 +74,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.tls).toBeDefined()
@@ -71,6 +89,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.tls).toBeUndefined()
@@ -85,6 +104,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     // Cluster client has different structure
@@ -103,6 +123,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.redisOptions.username).toBe('clusteruser')
@@ -119,6 +140,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.redisOptions.tls).toBeDefined()
@@ -134,6 +156,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     // ioredis sets undefined values to null
@@ -150,6 +173,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     // ioredis sets undefined values to null
@@ -164,6 +188,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.port).toBe(6379)
@@ -177,6 +202,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.options.db).toBe(0)
@@ -190,6 +216,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
   })
@@ -202,6 +229,7 @@ describe('buildRedisClient', () => {
     }
 
     const client = buildRedisClient(config, mockLogger)
+    createdClients.push(client)
 
     expect(client).toBeDefined()
     expect(client.listenerCount('connect')).toBeGreaterThan(0)

--- a/src/config.js
+++ b/src/config.js
@@ -411,6 +411,77 @@ const config = convict({
       default: './clients.jsonc',
       env: 'CLIENTS_PATH'
     }
+  },
+  redis: {
+    host: {
+      doc: 'Redis host',
+      format: String,
+      default: '127.0.0.1',
+      env: 'REDIS_HOST'
+    },
+    port: {
+      doc: 'Redis port',
+      format: 'port',
+      default: 6379,
+      env: 'REDIS_PORT'
+    },
+    username: {
+      doc: 'Redis username (for Redis 6+ ACL)',
+      format: String,
+      default: '',
+      env: 'REDIS_USERNAME'
+    },
+    password: {
+      doc: 'Redis password',
+      format: '*',
+      default: '',
+      sensitive: true,
+      env: 'REDIS_PASSWORD'
+    },
+    keyPrefix: {
+      doc: 'Redis cache key prefix name used to isolate the cached results across multiple clients',
+      format: String,
+      default: 'apha-integration-bridge:',
+      env: 'REDIS_KEY_PREFIX'
+    },
+    useSingleInstanceCache: {
+      doc: 'Connect to a single instance of redis instead of a cluster.',
+      format: Boolean,
+      default: !isProduction,
+      env: 'USE_SINGLE_INSTANCE_CACHE'
+    },
+    useTLS: {
+      doc: 'Connect to Redis using TLS',
+      format: Boolean,
+      default: isProduction,
+      env: 'REDIS_TLS'
+    },
+    db: {
+      doc: 'Redis database number',
+      format: Number,
+      default: 0,
+      env: 'REDIS_DB'
+    }
+  },
+  rateLimit: {
+    ratePerSecond: {
+      doc: 'Rate limit in requests per second per client',
+      format: Number,
+      default: 10,
+      env: 'RATE_LIMIT_RATE_PER_SECOND'
+    },
+    burstLimit: {
+      doc: 'Maximum burst capacity per client',
+      format: Number,
+      default: 20,
+      env: 'RATE_LIMIT_BURST_LIMIT'
+    },
+    duration: {
+      doc: 'Duration window in seconds for rate limiting',
+      format: Number,
+      default: 1,
+      env: 'RATE_LIMIT_DURATION'
+    }
   }
 })
 

--- a/src/config.js
+++ b/src/config.js
@@ -467,7 +467,7 @@ const config = convict({
     points: {
       doc: 'Maximum number of requests allowed per duration window per client',
       format: Number,
-      default: 20,
+      default: 10,
       env: 'RATE_LIMIT_POINTS'
     },
     duration: {

--- a/src/config.js
+++ b/src/config.js
@@ -464,17 +464,11 @@ const config = convict({
     }
   },
   rateLimit: {
-    ratePerSecond: {
-      doc: 'Rate limit in requests per second per client',
-      format: Number,
-      default: 10,
-      env: 'RATE_LIMIT_RATE_PER_SECOND'
-    },
-    burstLimit: {
-      doc: 'Maximum burst capacity per client',
+    points: {
+      doc: 'Maximum number of requests allowed per duration window per client',
       format: Number,
       default: 20,
-      env: 'RATE_LIMIT_BURST_LIMIT'
+      env: 'RATE_LIMIT_POINTS'
     },
     duration: {
       doc: 'Duration window in seconds for rate limiting',

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ import { versionPlugin } from './common/helpers/versioning.js'
 import { opentelemetryPlugin } from './common/helpers/telemetry.js'
 import { HTTPException } from './lib/http/http-exception.js'
 import { errorEnvelope } from './common/helpers/error-envelope.js'
+import { rateLimitPlugin } from './common/helpers/rate-limit.js'
 import { authPlugin } from './common/helpers/auth.js'
 import { piiContextPlugin } from './common/helpers/pii-context.js'
 import { clientScopesPlugin } from './common/helpers/client-scopes.js'
@@ -114,6 +115,10 @@ async function createServer() {
      * authenticates incoming requests using JWT tokens with signature verification
      */
     authPlugin,
+    /**
+     * rate limiting middleware - protects downstream resources (OracleDB)
+     */
+    rateLimitPlugin,
     /**
      * sets up opentelemetry tracing and metrics
      */


### PR DESCRIPTION
Implemented per-client rate limiting using Redis to track requests across EC2 instances.

**Key Features**
- Rate limiting: 10 requests per 1 second per client
- Per-client isolation: Each `client_id` from JWT has independent limits
- Redis-based: Distributed rate limiting across instances (with in-memory fallback for tests)
- Required headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`
- HTTP 429: Returns "Rate limit exceeded" when quota exhausted
- Configurable:  Via env vars `(RATE_LIMIT_POINTS, RATE_LIMIT_DURATION)`
- Exempt paths: `/health` endpoint not rate limited