### PR TITLE
fix: relax person first_name field to optional/nullable

### DIFF
--- a/src/lib/db/mappers/create-customer.js
+++ b/src/lib/db/mappers/create-customer.js
@@ -10,10 +10,8 @@ export const createCustomer = (row, id) => {
 
   const lastName = asNullableString(row.last_name)
 
-  if (!firstName || !lastName) {
-    throw new Error(
-      'Expected first_name and last_name to be populated for customer records'
-    )
+  if (!lastName) {
+    throw new Error('Expected last_name to be populated for customer records')
   }
 
   const title = asNullableString(row.title) ?? 'Unknown'

--- a/src/lib/db/mappers/create-customer.test.js
+++ b/src/lib/db/mappers/create-customer.test.js
@@ -56,12 +56,42 @@ test('createCustomer masks name fields when masking context is active', () => {
   })
 })
 
-test('createCustomer throws if first_name or last_name is missing', () => {
+test('createCustomer maps a person row with no first_name (null given name)', () => {
+  const customer = createCustomer(
+    {
+      title: 'Mr',
+      first_name: null,
+      second_name: null,
+      last_name: 'Farmer',
+      organisation_name: null,
+      primary_contact_full_name: null
+    },
+    'C123456'
+  )
+
+  expect(customer).toEqual({
+    type: 'customers',
+    id: 'C123456',
+    title: 'Mr',
+    firstName: null,
+    middleName: null,
+    lastName: 'Farmer',
+    addresses: [],
+    contactDetails: [],
+    relationships: {
+      srabpiPlants: {
+        data: []
+      }
+    }
+  })
+})
+
+test('createCustomer throws if last_name is missing', () => {
   expect(() =>
     createCustomer(
       {
         title: null,
-        first_name: null,
+        first_name: 'Bert',
         second_name: null,
         last_name: null,
         organisation_name: 'Acme Farms Ltd',
@@ -69,5 +99,5 @@ test('createCustomer throws if first_name or last_name is missing', () => {
       },
       'C777777'
     )
-  ).toThrow(/first_name.*last_name/i)
+  ).toThrow(/last_name/i)
 })

--- a/src/types/find/customers.js
+++ b/src/types/find/customers.js
@@ -42,7 +42,7 @@ const CustomerContactDetails = Joi.alternatives(EmailAddress, PhoneNumber)
 
 export const Customer = CustomersData.keys({
   title: Joi.string().required(),
-  firstName: Joi.string().required(),
+  firstName: Joi.string().required().allow(null),
   middleName: Joi.string().required().allow(null),
   lastName: Joi.string().required(),
   addresses: Joi.array().items(Address.keys({ isPreferred: Joi.boolean() })),


### PR DESCRIPTION
Confirmed against the real SAM Database Schema. The customers table defines `PERSON_GIVEN_NAME` as nullable. This fix relaxes this field in our API responses.
